### PR TITLE
Introduce clippy, rustfmt and cache to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,22 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --workspace --verbose
+
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy, rustfmt
+    - uses: Swatinem/rust-cache@v2
+    - name: rustfmt
+      run: cargo fmt --all -- --check
+    - name: clippy
+      run: cargo clippy --workspace -- -D warnings
+


### PR DESCRIPTION
Hi. Ferron is such an interesting project! How about introducing clippy, rustfmt and caching to CI workflow?

[rust-cache](https://github.com/Swatinem/rust-cache) not only caches necessary files and directories such as `~/.cargo` and `target`, but also removes unused dependencies before caching. Additionally, it disables incremental compilation `CARGO_INCREMENTAL=0`, which is unnecessary for CI environments.

rust-cache is used in large Rust open-source software projects such as axum and others.
ref: https://github.com/tokio-rs/axum/blob/cd2d5e1417e82b6fdc69c84847e438d9b37cd6a2/.github/workflows/CI.yml#L21