### PR TITLE
feat(docker): use distroless instead of devuan

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,17 @@ Thumbs.db
 # Temporary files used by the editor
 *.swp
 *.swo
+
+# Dockerfiles
+Dockerfile*
+
+# Hidden directories
+.*/
+
+# Documentation
+*.md
+
+# Configuration
+*.yaml
+# except
+!ferron-docker.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Rust image as a build stage
-FROM rust as builder
+FROM rust AS builder
 
 # Set the working directory
 WORKDIR /usr/src/ferron
@@ -7,34 +7,34 @@ WORKDIR /usr/src/ferron
 # Copy the source code
 COPY . .
 
-# Build the actual application
-RUN cargo build --release
+# Build the actual application (cache dependencies with BuildKit)
+RUN --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,sharing=private,target=/usr/src/ferron/target \
+    cargo build --release && \
+    # Copy executables out of the cache
+    mkdir .dist && cp target/release/ferron target/release/ferron-passwd .dist
 
-# Use a Devuan base image for the final image
-FROM devuan/devuan
+# Use a Distroless base image for the final image
+FROM gcr.io/distroless/cc-debian12:nonroot
 
 # Copy the compiled binaries from the builder stage
-COPY --from=builder /usr/src/ferron/target/release/ferron /usr/sbin/ferron
-COPY --from=builder /usr/src/ferron/target/release/ferron-passwd /usr/sbin/ferron-passwd
+COPY --from=builder /usr/src/ferron/.dist /usr/sbin
+
+# Switch to "nobody" user to make commands like WORKDIR use the correct owner
+USER nobody
 
 # Copy the web server configuration
-COPY ferron-docker.yaml /etc/ferron.yaml
+COPY --chown=nobody ferron-docker.yaml /etc/ferron.yaml
 
 # Copy the web root contents
-RUN mkdir -p /var/www/ferron
-COPY wwwroot/. /var/www/ferron/
+COPY --chown=nobody wwwroot /var/www/ferron/
 
 # Create a directory where Ferron logs are stored
-RUN mkdir -p /var/log/ferron
-
-# Create a "ferron" user and grant the permissions for the log directory and the webroot to that user
-RUN useradd -d /nonexistent -s /usr/sbin/nologin -r ferron && chown -hR ferron:ferron /var/www/ferron && chown -hR ferron:ferron /var/log/ferron
+WORKDIR /var/log/ferron
 
 # Expose the port 80 (used for HTTP)
 EXPOSE 80
-
-# Switch to "ferron" user
-USER ferron
 
 # Set the command to run the binary
 CMD ["/usr/sbin/ferron", "-c", "/etc/ferron.yaml"]


### PR DESCRIPTION
### Features
- Use [distroless](https://github.com/GoogleContainerTools/distroless/blob/main/examples/rust/Dockerfile) instead of devuan
- Allow arm64 builds (devuan is amd64 only)
- Improve security (nonroot image, nobody user and fewer vulnerabilities)
- Smaller image (45 MB instead of 128 MB)
- Cache cargo dependencies (with Docker BuildKit)
- Optimize docker build cache (minimize invalidation)

### devuan (debian 12.10) total: 61 (UNKNOWN: 2, LOW: 46, MEDIUM: 11, HIGH: 1, CRITICAL: 1)
| Library | Vulnerability | Severity | Installed |Fixed |
|-|-|-|-|-|
| apt | CVE-2011-3374 | LOW | 2.6.1devuan1 | |
| bash | TEMP-0841856-B18BAF | | 5.2.15-2+b8 | |
| bsdutils | CVE-2022-0563 | | 1:2.38.1-5+deb12u3devuan1 | |
| coreutils | CVE-2016-2781 | | 9.1-1 | |
| | CVE-2017-18018 | | | |
| gcc-12-base | CVE-2022-27943 | | 12.2.0-14+deb12u1 | |
| gpgv | CVE-2022-3219 | | 2.2.40-1.1 | |
| | CVE-2025-30258 | | | |
| libapt-pkg6.0 | CVE-2011-3374 | | 2.6.1devuan1 | |
| libblkid1 | CVE-2022-0563 | | 2.38.1-5+deb12u3devuan1 | |
| libc-bin | CVE-2010-4756 | | 2.36-9+deb12u10 | |
| | CVE-2018-20796 | | | |
| | CVE-2019-1010022 | | | |
| | CVE-2019-1010023 | | | |
| | CVE-2019-1010024 | | | |
| | CVE-2019-1010025 | | | |
| | CVE-2019-9192 | | | |
| | CVE-2025-4802 | UNKNOWN | | |
| libc6 | CVE-2010-4756 | LOW | | |
| | CVE-2018-20796 | | | |
| | CVE-2019-1010022 | | | |
| | CVE-2019-1010023 | | | |
| | CVE-2019-1010024 | | | |
| | CVE-2019-1010025 | | | |
| | CVE-2019-9192 | | | |
| | CVE-2025-4802 | UNKNOWN | | |
| libgcc-s1 | CVE-2022-27943 | LOW | 12.2.0-14+deb12u1 | |
| libgcrypt20 | CVE-2018-6829 | | 1.10.1-3 | |
| | CVE-2024-2236 | | | |
| libgnutls30 | CVE-2011-3389 | | 3.7.9-2+deb12u4 | |
| libmount1 | CVE-2022-0563 | | 2.38.1-5+deb12u3devuan1 | |
| libpam-modules | CVE-2024-10041 | MEDIUM | 1.5.2-6+deb12u1 | |
| | CVE-2024-22365 | | | |
| libpam-modules-bin | CVE-2024-10041 | | | |
| | CVE-2024-22365 | | | |
| libpam-runtime | CVE-2024-10041 | | | |
| | CVE-2024-22365 | | | |
| libpam0g | CVE-2024-10041 | | | |
| | CVE-2024-22365 | | | |
| libsmartcols1 | CVE-2022-0563 | LOW | 2.38.1-5+deb12u3devuan1 | |
| libstdc++6 | CVE-2022-27943 | | 12.2.0-14+deb12u1 | |
| libtinfo6 | CVE-2023-50495 | MEDIUM | 6.4-4 | |
| libuuid1 | CVE-2022-0563 | LOW | 2.38.1-5+deb12u3devuan1 | |
| login | CVE-2007-5686 | | 1:4.13+dfsg1-1+deb12u1 | |
| | CVE-2024-56433 | | | |
| | TEMP-0628843-DBAD28 | | | |
| mount | CVE-2022-0563 | | 2.38.1-5+deb12u3devuan1 | |
| ncurses-base | CVE-2023-50495 | MEDIUM | 6.4-4 | |
| ncurses-bin | | | | |
| passwd | CVE-2007-5686 | LOW | 1:4.13+dfsg1-1+deb12u1 | |
| | CVE-2024-56433 | | | |
| | TEMP-0628843-DBAD28 | | | |
| perl-base | CVE-2023-31484 | HIGH | 5.36.0-7+deb12u2 | |
| | CVE-2011-4116 | LOW | | |
| | CVE-2023-31486 | | | |
| sysvinit-utils | TEMP-0517018-A83CE6 | | 3.06-4devuan3 | |
| tar | CVE-2005-2541 | | 1.34+dfsg-1.2+deb12u1 | |
| | TEMP-0290435-0B57B5 | | | |
| util-linux | CVE-2022-0563 | | 2.38.1-5+deb12u3devuan1 | |
| util-linux-extra | | | | |
| zlib1g | CVE-2023-45853 | CRITICAL | 1:1.2.13.dfsg-1 | |

### distroless/cc-debian12:nonroot (debian 12.11) total: 12 (UNKNOWN: 1, LOW: 11)
| Library | Vulnerability | Severity | Installed |Fixed |
|-|-|-|-|-|
| gcc-12-base | CVE-2022-27943 | LOW | 12.2.0-14+deb12u1 | |
| libc6 | CVE-2010-4756 | | 2.36-9+deb12u10 | |
| | CVE-2018-20796 | | | |
| | CVE-2019-1010022 | | | |
| | CVE-2019-1010023 | | | |
| | CVE-2019-1010024 | | | |
| | CVE-2019-1010025 | | | |
| | CVE-2019-9192 | | | |
| | CVE-2025-4802 | UNKNOWN | | |
| libgcc-s1 | CVE-2022-27943 | LOW | 12.2.0-14+deb12u1 | |
| libgomp1 | | | | |
| libstdc++6 | | | | |

