### PR TITLE
support less-commonly-used HTTP verbs: PUT, PATCH, DELETE

### DIFF
--- a/ferron/src/modules/default_handler_checks.rs
+++ b/ferron/src/modules/default_handler_checks.rs
@@ -50,16 +50,26 @@ impl ServerModuleHandlers for DefaultHandlerChecksModuleHandlers {
             .response(
               Response::builder()
                 .status(StatusCode::NO_CONTENT)
-                .header(header::ALLOW, "GET, POST, HEAD, OPTIONS")
+                .header(
+                  header::ALLOW,
+                  "GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE",
+                )
                 .body(Empty::new().map_err(|e| match e {}).boxed())
                 .unwrap_or_default(),
             )
             .build(),
         ),
-        &Method::GET | &Method::POST | &Method::HEAD => Ok(ResponseData::builder(request).build()),
+        &Method::GET
+        | &Method::POST
+        | &Method::HEAD
+        | &Method::PUT
+        | &Method::PATCH
+        | &Method::DELETE => Ok(ResponseData::builder(request).build()),
         _ => {
           let mut header_map = HeaderMap::new();
-          if let Ok(header_value) = HeaderValue::from_str("GET, POST, HEAD, OPTIONS") {
+          if let Ok(header_value) =
+            HeaderValue::from_str("GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE")
+          {
             header_map.insert(header::ALLOW, header_value);
           };
           Ok(

--- a/ferron/src/request_handler.rs
+++ b/ferron/src/request_handler.rs
@@ -802,12 +802,17 @@ async fn request_handler_wrapped(
     let response = match request.method() {
       &Method::OPTIONS => Response::builder()
         .status(StatusCode::NO_CONTENT)
-        .header(header::ALLOW, "GET, POST, HEAD, OPTIONS")
+        .header(
+          header::ALLOW,
+          "GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE",
+        )
         .body(Empty::new().map_err(|e| match e {}).boxed())
         .unwrap_or_default(),
       _ => {
         let mut header_map = HeaderMap::new();
-        if let Ok(header_value) = HeaderValue::from_str("GET, POST, HEAD, OPTIONS") {
+        if let Ok(header_value) =
+          HeaderValue::from_str("GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE")
+        {
           header_map.insert(header::ALLOW, header_value);
         };
         generate_error_response(StatusCode::BAD_REQUEST, &combined_config, &Some(header_map)).await


### PR DESCRIPTION
Looks like Ruby-on-Rails apps heavily use less-commonly-used HTTP verbs, so this patch adds support for them.

I'm not entirely sure if this is the right way to patch in support for new HTTP verbs in general, but it did work on my server. Let me know what you think. In my case, I only need the extra verbs for a reverse proxied host, and I think this patch is more general than that?