### PR TITLE
hack in generation of host headers for reverse proxy targets

### DIFF
--- a/ferron/src/optional_modules/rproxy.rs
+++ b/ferron/src/optional_modules/rproxy.rs
@@ -135,6 +135,7 @@ impl ServerModuleHandlers for ReverseProxyModuleHandlers {
       let disable_certificate_verification = config["disableProxyCertificateVerification"]
         .as_bool()
         .unwrap_or(false);
+      let set_host_header = config["proxyHostHeader"].as_bool().unwrap_or(false);
       let proxy_intercept_errors = config["proxyInterceptErrors"].as_bool().unwrap_or(false);
       if let Some(proxy_to) = determine_proxy_to(
         config,
@@ -245,7 +246,10 @@ impl ServerModuleHandlers for ReverseProxyModuleHandlers {
         if let Some(original_host) = original_host {
           hyper_request_parts
             .headers
-            .insert("x-forwarded-host", original_host);
+            .insert("x-forwarded-host", original_host.clone());
+          if set_host_header {
+            hyper_request_parts.headers.insert("Host", original_host);
+          }
         }
 
         let proxy_request = Request::from_parts(hyper_request_parts, request_body);


### PR DESCRIPTION
One annoying web app (Mastodon, if you're curious) wants `host` headers instead of `x-forwarded-host` headers or it will plain refuse to work. So this patch hacks in support for generating a `host` header the same way the `x-forwarded-host` header is generated. But crucially, other apps behind the proxy fail if a `host` header is sent, so the configuration needs to support a per-host option to turn this on or off. This PR is my quick hack to get that working.

I wouldn't necessarily recommend merging this PR as-is, but I wanted to use the hack code to start a discussion about how to handle custom header needs in reverse proxy targets. This quick patch is enough to get my apps working, but might not be a good fit as a general contribution to Ferron the way it is now.

Maybe a better and more general way to solve this problem is to have some kind of configurable system for creating custom headers for proxy targets based on some kind of value templating using a collection of available variables. All the mainstream reverse proxy servers have something like this I think. For example, nginx has a configuration syntax like `proxy_set_header Host $host;`. What do you think?