### PR TITLE
mixed auto and manual TLS

### DIFF
--- a/ferron/src/server.rs
+++ b/ferron/src/server.rs
@@ -1143,7 +1143,13 @@ async fn server_event_loop(
       if let Some(host) = host_yaml.as_hash() {
         if let Some(domain_yaml) = host.get(&Yaml::from_str("domain")) {
           if let Some(domain) = domain_yaml.as_str() {
-            if !domain.contains("*") {
+            // check if we even want auto-TLS for this domain
+            let want_auto_tls = host
+              .get(&Yaml::from_str("enableAutomaticTLS"))
+              .and_then(|enable| enable.as_bool())
+              .unwrap_or(true);
+
+            if want_auto_tls && !domain.contains("*") {
               acme_domains.push(domain);
             }
           }

--- a/ferron/src/util/validate_config.rs
+++ b/ferron/src/util/validate_config.rs
@@ -727,17 +727,12 @@ pub fn validate_config(
     Err(anyhow::anyhow!("Invalid directory listing enabling option"))?
   }
 
-  if used_properties.contains("enableAutomaticTLS") {
-    if !is_global {
-      Err(anyhow::anyhow!(
-        "Automatic TLS enabling configuration is not allowed in host configuration"
-      ))?
-    }
-    if config["enableAutomaticTLS"].as_bool().is_none() {
-      Err(anyhow::anyhow!(
-        "Invalid automatic TLS enabling option value"
-      ))?
-    }
+  if used_properties.contains("enableAutomaticTLS")
+    && config["enableAutomaticTLS"].as_bool().is_none()
+  {
+    Err(anyhow::anyhow!(
+      "Invalid automatic TLS enabling option value"
+    ))?
   }
 
   if used_properties.contains("useAutomaticTLSHTTPChallenge") {


### PR DESCRIPTION
This is another PR that's meant to start a discussion, rather than accept the code as-is.

Basically, I found it really helpful to exclude some domains from auto-TLS while testing apps before they were ready for deployment.

In this case, I was migrating an app from one server to another, so it was impossible to get TLS certs for the app on the destination server since DNS hadn't been updated yet. But I still wanted to be able to test the app on the target server before finalizing the migration, but Ferron kept trying to get the TLS certs for every domain its hosts have and failing on the one domain with old DNS settings. It's common to edit your `/etc/hosts` file in these cases so you can test deployments locally without making them public yet, which gives you the effect of bypassing public DNS for a bit. So this patch allows configuring each domain to be included in auto-TLS, or not.

But, the reason why I think this might not be a good PR as-is is because it only solves part of the problem. Once you skip some domains during auto-TLS, you still want to be able to access them through Ferron. Either over regular HTTP without a cert, or over HTTPs with a local self-signed cert.

If you've generally configured Ferron to use HTTPs, then that basically rules out regular HTTP since the configuration isn't granular enough to be per-host. So one possible improvement would be to add per-host HTTPs settings.

If you still want to use HTTPs for all your hosts, even in local testing, then ideally you could attach a self-signed cert to the host and use than instead of the auto-TLS one. However, editing the `sni` configuration to add a self-signed cert to the host seemed to be ignored by Ferron in this case, possibly because auto-TLS was enabled. So another possible improvement here would be to allow Ferron to use the `sni` certs in cases when auto-TLS has been disabled for a host.

Hopefully that makes sense, and hopefully I've motivated the use case enough here. Let me know what you think, and if you have any questions.