### PR TITLE
perf, fix: performance improvement in cache module, fixes in URL sanitization, added dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "new_mime_guess",
  "nix 0.30.1",
  "ocsp-stapler",
+ "papaya",
  "password-auth",
  "pin-project-lite",
  "postcard",
@@ -2190,6 +2191,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "papaya"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6827e3fc394523c21d4464d02c0bb1c19966ea4a58a9844ad6d746214179d2bc"
+dependencies = [
+ "equivalent",
+ "seize",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3001,6 +3012,16 @@ checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "seize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b8d813387d566f627f3ea1b914c068aac94c40ae27ec43f5f33bde65abefe7"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/ferron/Cargo.toml
+++ b/ferron/Cargo.toml
@@ -126,6 +126,7 @@ mimalloc = { workspace = true }
 memchr = { version = "2.7.4", optional = true }
 itertools = { version = "0.14.0", optional = true }
 smallvec = { version = "1.15.0", features = ["write"] }
+papaya = "0.2.1"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/ferron/src/util/url_sanitizer.rs
+++ b/ferron/src/util/url_sanitizer.rs
@@ -181,9 +181,15 @@ pub fn sanitize_url(resource: &str, allow_double_slashes: bool) -> Result<String
 
   // Add trailing slash if it was originally present and we're not at the root directory
   // or if we are at root but the original path was just "/"
-  if preserve_trailing_slash
-    && (!final_segments.is_empty() || (final_segments.is_empty() && result.len() == 1))
-  {
+  // if preserve_trailing_slash
+  //   && (!final_segments.is_empty() || (final_segments.is_empty() && result.len() == 1))
+  // {
+  //   final_result.push(b'/');
+  // }
+
+  // Add trailing slash if it was originally present and we have segments,
+  // but don't add it if we're just dealing with the root "/"
+  if preserve_trailing_slash && !final_segments.is_empty() {
     final_result.push(b'/');
   }
 
@@ -213,6 +219,12 @@ fn hex_to_byte_fast(hi: u8, lo: u8) -> Result<u8> {
 mod tests {
   use super::*;
   use anyhow::Result;
+
+  #[test]
+  fn should_not_change_slash() -> Result<()> {
+    assert_eq!(sanitize_url("/", false)?, "/");
+    Ok(())
+  }
 
   #[test]
   fn should_return_asterisk_for_asterisk() -> Result<()> {


### PR DESCRIPTION
This pull request introduces significant changes to the `ferron` project, focusing on improving performance, simplifying concurrency handling, and refining API design. The primary updates include replacing `RwLock` with more efficient data structures, enhancing atomic cache implementation, and refining URL sanitization logic. Below is a categorized summary of the most important changes:

### Performance and Concurrency Improvements:
* Replaced `RwLock<HashMap>` with `papaya::HashMap` in `CacheModule` and `CacheModuleHandlers` to improve performance and reduce locking overhead. Corresponding updates were made to methods using the `vary_cache` field. (`ferron/src/modules/optional/cache.rs`) [[1]](diffhunk://#diff-d1cc3d96645b67c9f076ddbeb2c726460566452a4aa5f66464d6eb8f8632d5bcL61-R60) [[2]](diffhunk://#diff-d1cc3d96645b67c9f076ddbeb2c726460566452a4aa5f66464d6eb8f8632d5bcL164-R163) [[3]](diffhunk://#diff-d1cc3d96645b67c9f076ddbeb2c726460566452a4aa5f66464d6eb8f8632d5bcL199-R198) [[4]](diffhunk://#diff-d1cc3d96645b67c9f076ddbeb2c726460566452a4aa5f66464d6eb8f8632d5bcL289-R289) [[5]](diffhunk://#diff-d1cc3d96645b67c9f076ddbeb2c726460566452a4aa5f66464d6eb8f8632d5bcL471-R471)
* Updated `AtomicEntry` and `AtomicGenericCache` to use `UnsafeCell` instead of `RwLock` for fallback storage, reducing synchronization overhead. Added `unsafe impl` for `Sync` and `Send` traits to ensure thread safety. (`ferron/src/util/atomic_cache.rs`) [[1]](diffhunk://#diff-2f19ea50c11b9fdd7f06b37fba4ae16d76e40edd2cc8a8ae6e1c0827122a6d12L64-R88) [[2]](diffhunk://#diff-2f19ea50c11b9fdd7f06b37fba4ae16d76e40edd2cc8a8ae6e1c0827122a6d12L134-R150) [[3]](diffhunk://#diff-2f19ea50c11b9fdd7f06b37fba4ae16d76e40edd2cc8a8ae6e1c0827122a6d12L169-R189) [[4]](diffhunk://#diff-2f19ea50c11b9fdd7f06b37fba4ae16d76e40edd2cc8a8ae6e1c0827122a6d12R317-R331)

### API Refinements:
* Changed function signatures in `AtomicGenericCache` to use `Vec<K>` instead of slices (`&[K]`) for bulk operations like `get_all_by_keys`, `contains_any_key`, and `remove_all`, aligning with common usage patterns. (`ferron/src/util/atomic_cache.rs`) [[1]](diffhunk://#diff-2f19ea50c11b9fdd7f06b37fba4ae16d76e40edd2cc8a8ae6e1c0827122a6d12L755-R785) [[2]](diffhunk://#diff-2f19ea50c11b9fdd7f06b37fba4ae16d76e40edd2cc8a8ae6e1c0827122a6d12L783-R813) [[3]](diffhunk://#diff-2f19ea50c11b9fdd7f06b37fba4ae16d76e40edd2cc8a8ae6e1c0827122a6d12L881-R911) [[4]](diffhunk://#diff-2f19ea50c11b9fdd7f06b37fba4ae16d76e40edd2cc8a8ae6e1c0827122a6d12L937-R967)

### URL Sanitization Enhancements:
* Refined trailing slash handling in `sanitize_url` to ensure correct behavior for root paths (`"/"`) and other edge cases. Updated the logic to avoid unnecessary trailing slashes. (`ferron/src/util/url_sanitizer.rs`)
* Added a new test case to validate the updated behavior of the `sanitize_url` function. (`ferron/src/util/url_sanitizer.rs`)

### Testing and Stability:
* Introduced a new concurrent stress test for `AtomicGenericCache` to validate thread safety under high contention scenarios. (`ferron/src/util/atomic_cache.rs`)

### Miscellaneous:
* Removed unused imports (`HashMap` and `RwLock`) from `cache.rs` to clean up the codebase. (`ferron/src/modules/optional/cache.rs`) [[1]](diffhunk://#diff-d1cc3d96645b67c9f076ddbeb2c726460566452a4aa5f66464d6eb8f8632d5bcL1-R1) [[2]](diffhunk://#diff-d1cc3d96645b67c9f076ddbeb2c726460566452a4aa5f66464d6eb8f8632d5bcL17)

These changes collectively enhance the performance, maintainability, and robustness of the `ferron` project.