### PR TITLE
perf: replace std's HashMap with DashMap or Papaya HashMap.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +949,7 @@ dependencies = [
  "cache_control",
  "chrono",
  "clap",
+ "dashmap",
  "dirs",
  "fancy-regex",
  "fastrand",
@@ -1293,6 +1308,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
@@ -1306,7 +1327,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -1616,7 +1637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -3485,7 +3506,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown",
+ "hashbrown 0.15.3",
  "pin-project-lite",
  "slab",
  "tokio",

--- a/ferron/Cargo.toml
+++ b/ferron/Cargo.toml
@@ -133,6 +133,7 @@ itertools = { version = "0.14.0", optional = true }
 smallvec = { version = "1.15.0", features = ["write", "union", "const_generics"] }
 papaya = { version = "0.2.1", optional = true }
 ahash = "0.8.12"
+dashmap = { version = "6.1.0", features = ["inline"] }
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/ferron/src/config/adapters/kdl.rs
+++ b/ferron/src/config/adapters/kdl.rs
@@ -1,5 +1,5 @@
 use std::{
-  collections::{HashMap, HashSet},
+  collections::HashSet,
   error::Error,
   fs,
   net::{IpAddr, SocketAddr},
@@ -7,6 +7,7 @@ use std::{
   str::FromStr,
 };
 
+use dashmap::DashMap;
 use glob::glob;
 use kdl::{KdlDocument, KdlNode, KdlValue};
 
@@ -19,7 +20,7 @@ use super::ConfigurationAdapter;
 
 fn kdl_node_to_configuration_entry(kdl_node: &KdlNode) -> ServerConfigurationEntry {
   let mut values = Vec::new();
-  let mut props = HashMap::new();
+  let props = papaya::HashMap::with_hasher(ahash::RandomState::new());
   for kdl_entry in kdl_node.iter() {
     let value = match kdl_entry.value().to_owned() {
       KdlValue::String(value) => ServerConfigurationValue::String(value),
@@ -29,7 +30,7 @@ fn kdl_node_to_configuration_entry(kdl_node: &KdlNode) -> ServerConfigurationEnt
       KdlValue::Null => ServerConfigurationValue::Null,
     };
     if let Some(prop_name) = kdl_entry.name() {
-      props.insert(prop_name.value().to_string(), value);
+      props.pin().insert(prop_name.value().to_string(), value);
     } else {
       values.push(value);
     }
@@ -141,13 +142,17 @@ fn load_configuration_inner(
         (Some(global_name.to_string()), None, None)
       };
 
-      let mut configuration_entries: HashMap<String, ServerConfigurationEntries> = HashMap::new();
+      let configuration_entries: DashMap<String, ServerConfigurationEntries, ahash::RandomState> =
+        DashMap::with_hasher(ahash::RandomState::new());
       for kdl_node in children.nodes() {
         let kdl_node_name = kdl_node.name().value();
         let children = kdl_node.children();
         if kdl_node_name == "location" {
-          let mut configuration_entries: HashMap<String, ServerConfigurationEntries> =
-            HashMap::new();
+          let configuration_entries: DashMap<
+            String,
+            ServerConfigurationEntries,
+            ahash::RandomState,
+          > = DashMap::with_hasher(ahash::RandomState::new());
           if let Some(children) = children {
             if let Some(location) = kdl_node.entry(0) {
               if let Some(location_str) = location.value().as_string() {
@@ -155,15 +160,19 @@ fn load_configuration_inner(
                   let kdl_node_name = kdl_node.name().value();
                   let children = kdl_node.children();
                   if kdl_node_name == "error_config" {
-                    let mut configuration_entries: HashMap<String, ServerConfigurationEntries> =
-                      HashMap::new();
+                    let configuration_entries: DashMap<
+                      String,
+                      ServerConfigurationEntries,
+                      ahash::RandomState,
+                    > = DashMap::with_hasher(ahash::RandomState::new());
                     if let Some(children) = children {
                       if let Some(error_status_code) = kdl_node.entry(0) {
                         if let Some(error_status_code) = error_status_code.value().as_integer() {
                           for kdl_node in children.nodes() {
                             let kdl_node_name = kdl_node.name().value();
                             let value = kdl_node_to_configuration_entry(kdl_node);
-                            if let Some(entries) = configuration_entries.get_mut(kdl_node_name) {
+                            if let Some(mut entries) = configuration_entries.get_mut(kdl_node_name)
+                            {
                               entries.inner.push(value);
                             } else {
                               configuration_entries.insert(
@@ -197,7 +206,7 @@ fn load_configuration_inner(
                         for kdl_node in children.nodes() {
                           let kdl_node_name = kdl_node.name().value();
                           let value = kdl_node_to_configuration_entry(kdl_node);
-                          if let Some(entries) = configuration_entries.get_mut(kdl_node_name) {
+                          if let Some(mut entries) = configuration_entries.get_mut(kdl_node_name) {
                             entries.inner.push(value);
                           } else {
                             configuration_entries.insert(
@@ -228,7 +237,7 @@ fn load_configuration_inner(
                     }
                   } else {
                     let value = kdl_node_to_configuration_entry(kdl_node);
-                    if let Some(entries) = configuration_entries.get_mut(kdl_node_name) {
+                    if let Some(mut entries) = configuration_entries.get_mut(kdl_node_name) {
                       entries.inner.push(value);
                     } else {
                       configuration_entries.insert(
@@ -248,7 +257,7 @@ fn load_configuration_inner(
                     ServerConfigurationEntries {
                       inner: vec![ServerConfigurationEntry {
                         values: vec![ServerConfigurationValue::String(location_str.to_string())],
-                        props: HashMap::new(),
+                        props: papaya::HashMap::with_hasher(ahash::RandomState::new()),
                       }],
                     },
                   );
@@ -289,15 +298,18 @@ fn load_configuration_inner(
             ))?
           }
         } else if kdl_node_name == "error_config" {
-          let mut configuration_entries: HashMap<String, ServerConfigurationEntries> =
-            HashMap::new();
+          let configuration_entries: DashMap<
+            String,
+            ServerConfigurationEntries,
+            ahash::RandomState,
+          > = DashMap::with_hasher(ahash::RandomState::new());
           if let Some(children) = children {
             if let Some(error_status_code) = kdl_node.entry(0) {
               if let Some(error_status_code) = error_status_code.value().as_integer() {
                 for kdl_node in children.nodes() {
                   let kdl_node_name = kdl_node.name().value();
                   let value = kdl_node_to_configuration_entry(kdl_node);
-                  if let Some(entries) = configuration_entries.get_mut(kdl_node_name) {
+                  if let Some(mut entries) = configuration_entries.get_mut(kdl_node_name) {
                     entries.inner.push(value);
                   } else {
                     configuration_entries.insert(
@@ -331,7 +343,7 @@ fn load_configuration_inner(
               for kdl_node in children.nodes() {
                 let kdl_node_name = kdl_node.name().value();
                 let value = kdl_node_to_configuration_entry(kdl_node);
-                if let Some(entries) = configuration_entries.get_mut(kdl_node_name) {
+                if let Some(mut entries) = configuration_entries.get_mut(kdl_node_name) {
                   entries.inner.push(value);
                 } else {
                   configuration_entries.insert(
@@ -362,7 +374,7 @@ fn load_configuration_inner(
           }
         } else {
           let value = kdl_node_to_configuration_entry(kdl_node);
-          if let Some(entries) = configuration_entries.get_mut(kdl_node_name) {
+          if let Some(mut entries) = configuration_entries.get_mut(kdl_node_name) {
             entries.inner.push(value);
           } else {
             configuration_entries.insert(

--- a/ferron/src/modules/blocklist.rs
+++ b/ferron/src/modules/blocklist.rs
@@ -38,10 +38,10 @@ impl ModuleLoader for BlocklistModuleLoader {
       self
         .cache
         .get_or_init::<_, Box<dyn std::error::Error + Send + Sync>>(config, move |_| {
-          let mut blocklist_str_vec = Vec::new();
+          let mut blocklist_str_vec: Vec<String> = Vec::new();
           for blocked_ip_config in global_config.map_or(vec![], |c| get_values!("block", c)) {
             if let Some(blocked_ip) = blocked_ip_config.as_str() {
-              blocklist_str_vec.push(blocked_ip);
+              blocklist_str_vec.push(blocked_ip.into());
             }
           }
 
@@ -56,7 +56,8 @@ impl ModuleLoader for BlocklistModuleLoader {
   }
 
   fn get_requirements(&self) -> Vec<&'static str> {
-    vec!["block"]
+    const REQ: [&str; 1] = ["block"];
+    REQ.to_vec()
   }
 
   fn validate_configuration(

--- a/ferron/src/modules/core.rs
+++ b/ferron/src/modules/core.rs
@@ -43,7 +43,10 @@ impl ModuleLoader for CoreModuleLoader {
           Ok(Arc::new(CoreModule {
             default_http_port: global_config
               .and_then(|c| get_entry!("default_http_port", c))
-              .and_then(|e| e.values.first())
+              .and_then(|e| {
+                let first = e.values.first();
+                first.cloned()
+              })
               .map_or(Some(80), |v| {
                 if v.is_null() {
                   None
@@ -53,7 +56,10 @@ impl ModuleLoader for CoreModuleLoader {
               }),
             default_https_port: global_config
               .and_then(|c| get_entry!("default_https_port", c))
-              .and_then(|e| e.values.first())
+              .and_then(|e| {
+                let first = e.values.first();
+                first.cloned()
+              })
               .map_or(Some(443), |v| {
                 if v.is_null() {
                   None
@@ -587,9 +593,9 @@ impl ModuleHandlers for CoreModuleHandlers {
     if !is_proxy_request {
       // Remove the location prefix using an undocumented configuration property
       if let Some(path) =
-        get_value!("UNDOCUMENTED_REMOVE_PATH_PREFIX", config).and_then(|v| v.as_str())
+        get_value!("UNDOCUMENTED_REMOVE_PATH_PREFIX", config).and_then(|v| v.to_string())
       {
-        let mut path_without_trailing_slashes = path;
+        let mut path_without_trailing_slashes = path.as_str();
         while path_without_trailing_slashes.ends_with("/") {
           path_without_trailing_slashes =
             &path_without_trailing_slashes[..(path_without_trailing_slashes.len() - 1)];

--- a/ferron/src/modules/optional/cgi.rs
+++ b/ferron/src/modules/optional/cgi.rs
@@ -180,7 +180,7 @@ impl ModuleHandlers for CgiModuleHandlers {
     let mut cgi_script_exts = Vec::new();
 
     let cgi_script_exts_config = get_entries!("cgi_extension", config);
-    if let Some(cgi_script_exts_obtained) = cgi_script_exts_config {
+    if let Some(cgi_script_exts_obtained) = cgi_script_exts_config.as_ref() {
       for cgi_script_ext_config in cgi_script_exts_obtained.inner.iter() {
         if let Some(cgi_script_ext) = cgi_script_ext_config
           .values
@@ -193,8 +193,11 @@ impl ModuleHandlers for CgiModuleHandlers {
     }
 
     if let Some(wwwroot) = get_entry!("root", config)
-      .and_then(|e| e.values.first())
-      .and_then(|v| v.as_str())
+      .and_then(|e| {
+        let first = e.values.first();
+        first.cloned()
+      })
+      .and_then(|v| v.to_string())
     {
       let request_path = request.uri().path();
       let mut request_path_bytes = request_path.bytes();
@@ -525,7 +528,7 @@ impl ModuleHandlers for CgiModuleHandlers {
           wwwroot,
           execute_pathbuf,
           execute_path_info,
-          get_value!("server_administrator_email", config).and_then(|v| v.as_str()),
+          get_value!("server_administrator_email", config).and_then(|v| v.to_string()),
           cgi_interpreters,
           additional_environment_variables,
         )
@@ -551,7 +554,7 @@ async fn execute_cgi_with_environment_variables(
   wwwroot: &Path,
   execute_pathbuf: PathBuf,
   path_info: Option<String>,
-  server_administrator_email: Option<&str>,
+  server_administrator_email: Option<String>,
   cgi_interpreters: HashMap<String, Vec<String>>,
   additional_environment_variables: HashMap<String, String>,
 ) -> Result<ResponseData, Box<dyn Error + Send + Sync>> {

--- a/ferron/src/modules/optional/fauth.rs
+++ b/ferron/src/modules/optional/fauth.rs
@@ -169,8 +169,11 @@ impl ModuleHandlers for ForwardedAuthenticationModuleHandlers {
       .filter_map(|v| v.as_str().map(|v| v.to_string()))
       .collect::<Vec<_>>();
     if let Some(auth_to) = get_entry!("auth_to", config)
-      .and_then(|e| e.values.first())
-      .and_then(|v| v.as_str())
+      .and_then(|e| {
+        let first = e.values.first();
+        first.cloned()
+      })
+      .and_then(|v| v.to_string())
     {
       let (request_parts, request_body) = request.into_parts();
 

--- a/ferron/src/modules/optional/memcache.rs
+++ b/ferron/src/modules/optional/memcache.rs
@@ -316,7 +316,10 @@ impl ModuleLoader for CacheModuleLoader {
         .get_or_init::<_, Box<dyn std::error::Error + Send + Sync>>(config, |_| {
           let maximum_cache_entries = global_config
             .and_then(|c| get_entry!("cache_max_entries", c))
-            .and_then(|e| e.values.first())
+            .and_then(|e| {
+              let first = e.values.first();
+              first.cloned()
+            })
             .and_then(|v| v.as_i128())
             .map(|v| v as usize);
 

--- a/ferron/src/modules/optional/scgi.rs
+++ b/ferron/src/modules/optional/scgi.rs
@@ -130,8 +130,11 @@ impl ModuleHandlers for ScgiModuleHandlers {
     error_logger: &ErrorLogger,
   ) -> Result<ResponseData, Box<dyn Error + Send + Sync>> {
     if let Some(scgi_to) = get_entry!("scgi", config)
-      .and_then(|e| e.values.first())
-      .and_then(|v| v.as_str())
+      .and_then(|e| {
+        let first = e.values.first();
+        first.cloned()
+      })
+      .and_then(|v| v.to_string())
     {
       let request_path = request.uri().path();
       let mut request_path_bytes = request_path.bytes();
@@ -146,9 +149,12 @@ impl ModuleHandlers for ScgiModuleHandlers {
       }
 
       let wwwroot = get_entry!("root", config)
-        .and_then(|e| e.values.first())
-        .and_then(|v| v.as_str())
-        .unwrap_or("/nonexistent");
+        .and_then(|e| {
+          let first = e.values.first();
+          first.cloned()
+        })
+        .and_then(|v| v.to_string())
+        .unwrap_or("/nonexistent".into());
 
       let wwwroot_unknown = PathBuf::from(wwwroot);
       let wwwroot_pathbuf = match wwwroot_unknown.as_path().is_absolute() {
@@ -216,8 +222,8 @@ impl ModuleHandlers for ScgiModuleHandlers {
         wwwroot,
         execute_pathbuf,
         execute_path_info,
-        get_value!("server_administrator_email", config).and_then(|v| v.as_str()),
-        scgi_to,
+        get_value!("server_administrator_email", config).and_then(|v| v.to_string()),
+        &scgi_to,
         additional_environment_variables,
       )
       .await;
@@ -241,7 +247,7 @@ async fn execute_scgi_with_environment_variables(
   wwwroot: &Path,
   execute_pathbuf: PathBuf,
   path_info: Option<String>,
-  server_administrator_email: Option<&str>,
+  server_administrator_email: Option<String>,
   scgi_to: &str,
   additional_environment_variables: HashMap<String, String>,
 ) -> Result<ResponseData, Box<dyn Error + Send + Sync>> {

--- a/ferron/src/modules/optional/static.rs
+++ b/ferron/src/modules/optional/static.rs
@@ -399,8 +399,11 @@ impl ModuleHandlers for StaticFileServingModuleHandlers {
 
     // Get the web root directory from configuration
     if let Some(wwwroot) = get_entry!("root", config)
-      .and_then(|e| e.values.first())
-      .and_then(|v| v.as_str())
+      .and_then(|e| {
+        let first = e.values.first();
+        first.cloned()
+      })
+      .and_then(|v| v.to_string())
     {
       // Extract and validate the request path
       let request_path = request.uri().path();
@@ -448,7 +451,7 @@ impl ModuleHandlers for StaticFileServingModuleHandlers {
         Some(joined_pathbuf) => joined_pathbuf,
         // Otherwise, construct the file path
         None => {
-          let path = Path::new(wwwroot);
+          let path = Path::new(&wwwroot);
           // Strip leading slash and normalize path
           let mut relative_path = &request_path[1..];
           while relative_path.as_bytes().first().copied() == Some(b'/') {

--- a/ferron/src/modules/rewrite.rs
+++ b/ferron/src/modules/rewrite.rs
@@ -75,21 +75,25 @@ impl ModuleLoader for RewriteModuleLoader {
               };
               let is_not_directory = !rewrite_config_entry
                 .props
+                .pin_owned()
                 .get("directory")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(true);
               let is_not_file = !rewrite_config_entry
                 .props
+                .pin_owned()
                 .get("file")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(true);
               let last = rewrite_config_entry
                 .props
+                .pin_owned()
                 .get("last")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
               let allow_double_slashes = rewrite_config_entry
                 .props
+                .pin_owned()
                 .get("allow_double_slashes")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
@@ -130,20 +134,36 @@ impl ModuleLoader for RewriteModuleLoader {
           Err(anyhow::anyhow!(
             "The URL rewrite replacement must be a string"
           ))?
-        } else if !entry.props.get("directory").is_none_or(|v| v.is_bool()) {
+        } else if !entry
+          .props
+          .pin_owned()
+          .get("directory")
+          .is_none_or(|v| v.is_bool())
+        {
           Err(anyhow::anyhow!(
             "The URL rewrite disabling when it's a directory option must be boolean"
           ))?
-        } else if !entry.props.get("file").is_none_or(|v| v.is_bool()) {
+        } else if !entry
+          .props
+          .pin_owned()
+          .get("file")
+          .is_none_or(|v| v.is_bool())
+        {
           Err(anyhow::anyhow!(
             "The URL rewrite disabling when it's a file option must be boolean"
           ))?
-        } else if !entry.props.get("last").is_none_or(|v| v.is_bool()) {
+        } else if !entry
+          .props
+          .pin_owned()
+          .get("last")
+          .is_none_or(|v| v.is_bool())
+        {
           Err(anyhow::anyhow!(
             "The URL rewrite last rule option must be boolean"
           ))?
         } else if !entry
           .props
+          .pin_owned()
           .get("allow_double_slashes")
           .is_none_or(|v| v.is_bool())
         {
@@ -225,10 +245,13 @@ impl ModuleHandlers for RewriteModuleHandlers {
       // Check if it's a file or a directory according to the rewrite map configuration
       if url_rewrite_map_entry.is_not_directory || url_rewrite_map_entry.is_not_file {
         if let Some(wwwroot) = get_entry!("root", config)
-          .and_then(|e| e.values.first())
-          .and_then(|v| v.as_str())
+          .and_then(|e| {
+            let first = e.values.first();
+            first.cloned()
+          })
+          .and_then(|v| v.to_string())
         {
-          let path = Path::new(wwwroot);
+          let path = Path::new(&wwwroot);
           let mut relative_path = &rewritten_url[1..];
           while relative_path.as_bytes().first().copied() == Some(b'/') {
             relative_path = &relative_path[1..];

--- a/ferron/src/modules/status_codes.rs
+++ b/ferron/src/modules/status_codes.rs
@@ -72,6 +72,7 @@ impl ModuleLoader for StatusCodesModuleLoader {
               };
               let regex = match non_standard_code_config_entry
                 .props
+                .pin_owned()
                 .get("regex")
                 .and_then(|v| v.as_str())
               {
@@ -89,6 +90,7 @@ impl ModuleLoader for StatusCodesModuleLoader {
               };
               let url = non_standard_code_config_entry
                 .props
+                .pin_owned()
                 .get("url")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
@@ -99,21 +101,25 @@ impl ModuleLoader for StatusCodesModuleLoader {
               }
               let location = non_standard_code_config_entry
                 .props
+                .pin_owned()
                 .get("location")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
               let realm = non_standard_code_config_entry
                 .props
+                .pin_owned()
                 .get("realm")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
               let disable_brute_force_protection = !non_standard_code_config_entry
                 .props
+                .pin_owned()
                 .get("brute_protection")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(true);
               let user_list = non_standard_code_config_entry
                 .props
+                .pin_owned()
                 .get("users")
                 .and_then(|v| v.as_str())
                 .map(|userlist| {
@@ -124,11 +130,15 @@ impl ModuleLoader for StatusCodesModuleLoader {
                 });
               let users = match non_standard_code_config_entry
                 .props
+                .pin_owned()
                 .get("allowed")
                 .and_then(|v| v.as_str())
               {
                 Some(userlist) => {
-                  let users_str_vec = userlist.split(",").collect::<Vec<_>>();
+                  let users_str_vec = userlist
+                    .split(",")
+                    .map(|f| f.into())
+                    .collect::<Vec<String>>();
 
                   let mut users_init = IpBlockList::new();
                   users_init.load_from_vec(users_str_vec);
@@ -169,40 +179,69 @@ impl ModuleLoader for StatusCodesModuleLoader {
           ))?
         } else if !entry.values[0].is_integer() {
           Err(anyhow::anyhow!("The custom status code must be a string"))?
-        } else if !entry.props.contains_key("url") && !entry.props.contains_key("regex") {
+        } else if !entry.props.pin_owned().contains_key("url")
+          && !entry.props.pin_owned().contains_key("regex")
+        {
           Err(anyhow::anyhow!(
             "Non-standard codes must either include URL or a matching regular expression"
           ))?
-        } else if !entry.props.get("url").is_none_or(|v| v.is_string()) {
+        } else if !entry
+          .props
+          .pin_owned()
+          .get("url")
+          .is_none_or(|v| v.is_string())
+        {
           Err(anyhow::anyhow!(
             "The custom status code URL must be a string"
           ))?
-        } else if !entry.props.get("regex").is_none_or(|v| v.is_string()) {
+        } else if !entry
+          .props
+          .pin_owned()
+          .get("regex")
+          .is_none_or(|v| v.is_string())
+        {
           Err(anyhow::anyhow!(
             "The custom status code regular expression must be a string"
           ))?
-        } else if !entry.props.get("location").is_none_or(|v| v.is_string()) {
+        } else if !entry
+          .props
+          .pin_owned()
+          .get("location")
+          .is_none_or(|v| v.is_string())
+        {
           Err(anyhow::anyhow!(
             "The custom status code redirect destination must be a string"
           ))?
-        } else if !entry.props.get("realm").is_none_or(|v| v.is_string()) {
+        } else if !entry
+          .props
+          .pin_owned()
+          .get("realm")
+          .is_none_or(|v| v.is_string())
+        {
           Err(anyhow::anyhow!(
             "The custom status code HTTP authentication realm must be a string"
           ))?
         } else if !entry
           .props
+          .pin_owned()
           .get("brute_protection")
           .is_none_or(|v| v.is_bool())
         {
           Err(anyhow::anyhow!(
                         "The custom status code HTTP authentication brute-force protection realm must be boolean"
                     ))?
-        } else if !entry.props.get("users").is_none_or(|v| v.is_string()) {
+        } else if !entry
+          .props
+          .pin_owned()
+          .get("users")
+          .is_none_or(|v| v.is_string())
+        {
           Err(anyhow::anyhow!(
             "The custom status code HTTP authentication allowed users list must be a string"
           ))?
         } else if !entry
           .props
+          .pin_owned()
           .get("brute_protection")
           .is_none_or(|v| v.is_string())
         {

--- a/ferron/src/modules/trailing.rs
+++ b/ferron/src/modules/trailing.rs
@@ -111,8 +111,11 @@ impl ModuleHandlers for TrailingSlashRedirectsModuleHandlers {
       .unwrap_or(false)
     {
       if let Some(wwwroot) = get_entry!("root", config)
-        .and_then(|e| e.values.first())
-        .and_then(|v| v.as_str())
+        .and_then(|e| {
+          let first = e.values.first();
+          first.cloned()
+        })
+        .and_then(|v| v.to_string())
       {
         let request_path = request.uri().path();
         let request_query = request.uri().query();
@@ -179,7 +182,7 @@ impl ModuleHandlers for TrailingSlashRedirectsModuleHandlers {
             } else {
               drop(read_rwlock);
 
-              let path = Path::new(wwwroot);
+              let path = Path::new(&wwwroot);
               let mut relative_path = &request_path[1..];
               while relative_path.as_bytes().first().copied() == Some(b'/') {
                 relative_path = &relative_path[1..];

--- a/ferron/src/util/config_macros.rs
+++ b/ferron/src/util/config_macros.rs
@@ -3,7 +3,7 @@ macro_rules! get_entries_for_validation {
   ($name:literal, $config:expr, $used:expr) => {{
     $config.entries.get($name).and_then(|value| {
       $used.insert($name.to_string());
-      value.get_value().map(|_| value)
+      value.get_value().map(|_| value.clone())
     })
   }};
 }
@@ -16,9 +16,15 @@ macro_rules! get_values_for_validation {
       .get($name)
       .and_then(|value| {
         $used.insert($name.to_string());
-        value.get_value().map(|_| value)
+        value.get_value().map(|_| value.clone())
       })
-      .map_or(Vec::new(), |value| value.get_values())
+      .map_or(Vec::new(), |value| {
+        value
+          .get_values()
+          .into_iter()
+          .map(|v| v.clone())
+          .collect::<Vec<_>>()
+      })
   }};
 }
 
@@ -28,7 +34,7 @@ macro_rules! get_entries {
     $config
       .entries
       .get($name)
-      .and_then(|value| value.get_value().map(|_| value))
+      .and_then(|value| value.get_value().map(|_| value.clone()))
   }};
 }
 
@@ -38,8 +44,8 @@ macro_rules! get_entry {
     $config
       .entries
       .get($name)
-      .and_then(|value| value.get_value().map(|_| value))
-      .and_then(|value| value.get_entry())
+      .and_then(|value| value.get_value().map(|_| value.clone()))
+      .and_then(|value| value.get_entry().cloned())
   }};
 }
 
@@ -49,8 +55,8 @@ macro_rules! get_value {
     $config
       .entries
       .get($name)
-      .and_then(|value| value.get_value().map(|_| value))
-      .and_then(|value| value.get_value())
+      .and_then(|value| value.get_value().map(|_| value.clone()))
+      .and_then(|value| value.get_value().cloned())
   }};
 }
 
@@ -60,8 +66,10 @@ macro_rules! get_values {
     $config
       .entries
       .get($name)
-      .and_then(|value| value.get_value().map(|_| value))
-      .map_or(Vec::new(), |value| value.get_values())
+      .and_then(|value| value.get_value().map(|_| value.clone()))
+      .map_or(Vec::new(), |value| {
+        value.get_values().into_iter().map(|v| v.clone()).collect()
+      })
   }};
 }
 

--- a/ferron/src/util/error_pages.rs
+++ b/ferron/src/util/error_pages.rs
@@ -3,7 +3,7 @@ use super::anti_xss;
 /// Generates a default error page
 pub fn generate_default_error_page(
   status_code: hyper::StatusCode,
-  server_administrator_email: Option<&str>,
+  server_administrator_email: Option<String>,
 ) -> String {
   let status_code_name = match status_code.canonical_reason() {
     Some(reason) => format!("{} {}", status_code.as_u16(), reason),

--- a/ferron/src/util/ip_blocklist.rs
+++ b/ferron/src/util/ip_blocklist.rs
@@ -15,9 +15,9 @@ impl IpBlockList {
   }
 
   /// Loads the block list from a vector of IP address strings
-  pub fn load_from_vec(&mut self, ip_list: Vec<&str>) {
+  pub fn load_from_vec(&mut self, ip_list: Vec<String>) {
     for ip_str in ip_list {
-      match ip_str {
+      match ip_str.as_str() {
         "localhost" => {
           self
             .blocked_ips
@@ -45,7 +45,7 @@ mod tests {
   #[test]
   fn test_ip_block_list() {
     let mut block_list = IpBlockList::new();
-    block_list.load_from_vec(vec!["192.168.1.1", "10.0.0.1"]);
+    block_list.load_from_vec(vec!["192.168.1.1".into(), "10.0.0.1".into()]);
 
     assert!(block_list.is_blocked("192.168.1.1".parse().unwrap()));
     assert!(block_list.is_blocked("10.0.0.1".parse().unwrap()));


### PR DESCRIPTION
This pull request introduces significant changes to the `ferron` codebase to improve performance and concurrency by replacing `HashMap` with `DashMap` and `papaya::HashMap`. Additionally, it introduces utility methods and refactors data structures for better usability and deterministic behavior. Below is a summary of the most important changes grouped by theme.

### Performance and Concurrency Improvements:
* Replaced `HashMap` with `DashMap` in `ServerConfiguration` and related functions to enable thread-safe concurrent access. [[1]](diffhunk://#diff-2bcdca6d9b8fcbe669791ae13ef32829bd9ff0498aa0e978ed24f43ce627cc5bL144-R175) [[2]](diffhunk://#diff-5d6f4502fe760cd8d7734cab4c0b7016949979697ef6ef98223911f628993000L119-R151) [[3]](diffhunk://#diff-3bfd9b6acac47d7c0328ff640ca433e4a8adf922f65cadda4b67795e0ce01b35L100-R102)
* Updated `props` field in `ServerConfigurationEntry` to use `papaya::HashMap` for improved hashing performance. [[1]](diffhunk://#diff-2bcdca6d9b8fcbe669791ae13ef32829bd9ff0498aa0e978ed24f43ce627cc5bL22-R23) [[2]](diffhunk://#diff-5d6f4502fe760cd8d7734cab4c0b7016949979697ef6ef98223911f628993000L20-R21) [[3]](diffhunk://#diff-3bfd9b6acac47d7c0328ff640ca433e4a8adf922f65cadda4b67795e0ce01b35L231-R245)

### Deterministic Behavior:
* Refactored hashing logic for `props` in `ServerConfigurationEntry` to ensure deterministic iteration order using `smallvec::SmallVec`.

### Utility Enhancements:
* Added a new method `to_string` in `ServerConfigurationValue` to extract `&str` values conveniently.

### Dependency Updates:
* Added `dashmap` as a new dependency in `Cargo.toml` with the `inline` feature enabled.

These changes collectively enhance the codebase's efficiency, maintainability, and usability.