### PR TITLE
CGI: Fix cgi_interpreter configuration validation and execution

### DIFF
--- a/ferron-modules-builtin/src/optional/cgi.rs
+++ b/ferron-modules-builtin/src/optional/cgi.rs
@@ -894,7 +894,6 @@ async fn execute_cgi(
   })
 }
 
-
 #[allow(dead_code)]
 #[cfg(unix)]
 async fn get_executable(execute_pathbuf: &PathBuf) -> Result<Vec<String>, Box<dyn Error + Send + Sync>> {
@@ -912,7 +911,6 @@ async fn get_executable(execute_pathbuf: &PathBuf) -> Result<Vec<String>, Box<dy
   let executable_params_vector = vec![execute_pathbuf.to_string_lossy().to_string()];
   Ok(executable_params_vector)
 }
-
 
 #[allow(dead_code)]
 #[cfg(all(feature = "runtime-monoio", not(unix)))]


### PR DESCRIPTION
- Fixed cgi_interpreter configuration validation. Probably a typo on validate_configuration()?
- Also corrected get_executable function on unix systems. The program tried to execute files without shebang without assigning the configured cgi_interpreter. 