### PR TITLE
Add example for reverse proxy with Unix domain socket.

### DIFF
--- a/docs/configuration-kdl.md
+++ b/docs/configuration-kdl.md
@@ -484,7 +484,7 @@ example.com {
 ### Reverse proxy & load balancing
 
 - `proxy <proxy_to: string|null> [unix=<unix_socket_path: string>]` (_rproxy_ module)
-  - This directive specifies the URL to which the reverse proxy should forward requests. HTTP (for example `http://localhost:3000/`) and HTTPS URLs (for example `https://localhost:3000/`) are supported. Unix sockets are also supported via the `unix` prop set to the path to the socket, supported only on Unix and Unix-like systems. This directive can be specified multiple times. Default: none
+  - This directive specifies the URL to which the reverse proxy should forward requests. HTTP (for example `http://localhost:3000/`) and HTTPS URLs (for example `https://localhost:3000/`) are supported. Unix sockets are also supported via the `unix` prop set to the path to the socket (and the main value is set to the URL of the website), supported only on Unix and Unix-like systems. This directive can be specified multiple times. Default: none
 - `lb_health_check [enable_lb_health_check: bool]` (_rproxy_ module)
   - This directive specifies whenever the load balancer passive health check is enabled. Default: `lb_health_check #false`
 - `lb_health_check_max_fails <max_fails: integer>` (_rproxy_ module)

--- a/docs/use-cases/reverse-proxy.md
+++ b/docs/use-cases/reverse-proxy.md
@@ -9,6 +9,11 @@ Configuring Ferron as a reverse proxy is straightforward - you just need to spec
 example.com {
     proxy "http://localhost:3000/" // Replace "http://localhost:3000" with the backend server URL
 }
+// Reverse proxy to Unix domain socket. Set `unix` propery to the path of the socket.
+// The main value of `proxy` directive is set to the URL of the site.
+example.com {
+    proxy "http://example.com" unix="/run/backend/web.sock"
+}
 ```
 
 ## Reverse proxy with static file serving support


### PR DESCRIPTION
One more thing:
I don't know if it is intentional, but when using reverse proxy with Unix domain socket, setting `proxy` value to empty string or `null`, the page will throw error 500 when being visited, and write this to error log:

```
Unexpected error while serving a request: empty string
```

If this is not intentional, I propose to support:

```kdl
proxy #null unix="/path/to/socket"
```

to make the config simple.