### PR TITLE
docs(kdl config): change users to user to reflect the configuration correctly

### DIFF
--- a/docs/configuration-kdl.md
+++ b/docs/configuration-kdl.md
@@ -370,9 +370,9 @@ example.com {
 
 - `trust_x_forwarded_for [trust_x_forwarded_for: bool]`
   - This directive specifies whenever to trust the value of the `X-Forwarded-For` header. It's recommended to configure this directive if behind a reverse proxy. Default: `trust_x_forwarded_for #false`
-- `status <status_code: integer> [url=<url: string>|regex=<regex: string>] [location=<location: string>] [realm=<realm: string>] [brute_protection=<enable_brute_protection: bool>] [users=<users: string>] [allowed=<allowed: string>] [not_allowed=<not_allowed: string>] [body=<response_body: string>]`
+- `status <status_code: integer> [url=<url: string>|regex=<regex: string>] [location=<location: string>] [realm=<realm: string>] [brute_protection=<enable_brute_protection: bool>] [user=<user: string>] [allowed=<allowed: string>] [not_allowed=<not_allowed: string>] [body=<response_body: string>]`
   - This directive specifies the custom status code. This directive can be specified multiple times. The `url` prop specifies the request path for this status code. The `regex` prop specifies the regular expression (like `^/ferron(?:$|[/#?])`) for the custom status code. The `location` prop specifies the destination for the redirect; it supports placeholders like `{path}` which will be replaced with the request path. The `realm` prop specifies the HTTP basic authentication realm. The `brute_protection` prop specifies whenever the brute-force protection is enabled. The `users` prop is a comma-separated list of allowed users for HTTP authentication. The `allowed` prop is a comma-separated list of IP addresses applicable for the status code. The `not_allowed` prop is a comma-separated list of IP addresses not applicable for the status code. The `body` prop specifies the response body to be sent. Default: none
-- `users [username: string] [password_hash: string]`
+- `user [username: string] [password_hash: string]`
   - This directive specifies an user with a password hash used for the HTTP basic authentication (it can be either Argon2, PBKDF2, or `scrypt` one). It's recommended to use the `ferron-passwd` tool to generate the password hash. This directive can be specified multiple times. Default: none
 - `block (<blocked_ip: string> [<blocked_ip: string> ...])|<not_specified: null>`
   - This directive specifies IP addresses and CIDR ranges to be blocked. If set as `block #null`, this directive is ignored. This directive was global-only before Ferron UNRELEASED. This directive can be specified multiple times. Default: none
@@ -391,8 +391,8 @@ example.com {
     status 301 url="/old-page" location="/new-page"
 
     // User definitions for authentication (use `ferron-passwd` to generate password hashes)
-    users "admin" "$2b$10$hashedpassword12345"
-    users "moderator" "$2b$10$anotherhashedpassword"
+    user "admin" "$2b$10$hashedpassword12345"
+    user "moderator" "$2b$10$anotherhashedpassword"
 
     // Limit who can access the site
     block "192.168.1.100" "10.0.0.5"


### PR DESCRIPTION
Had a little problem configuring basic auth, the users field in the code is being get with user instead, switched to user and worked correctly