### PR TITLE
WIP: SNI-aware proxy with tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,8 +4083,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+source = "git+https://github.com/selfhoster1312/rustls?branch=more-public-types#3b0d897225194ab78965031adfd9c6d65c136f76"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ferron-modules-builtin = { path = "./ferron-modules-builtin", default-features =
 ferron-observability-builtin = { path = "./ferron-observability-builtin", default-features = false }
 
 [patch.crates-io]
+rustls = { git = "https://github.com/selfhoster1312/rustls", branch = "more-public-types" }
 monoio = { git = "https://github.com/DorianNiemiecSVRJS/monoio.git" }                                           # This is needed for the web server to be able to accept more than one connection on Windows, and to be able to be compiled correctly on FreeBSD
 cache_control = { git = "https://github.com/DorianNiemiecSVRJS/rust-cache-control.git" }                        # This is a fork of "cache-control" crate, with a bugfix related to "s-maxage" directive
 desec_api = { git = "https://github.com/DorianNiemiecSVRJS/desec_api.git" }                                     # This is a fork of "desec_api" crate, with updated dependencies and crypto provider requirement removed

--- a/ferron/src/main.rs
+++ b/ferron/src/main.rs
@@ -397,6 +397,7 @@ fn before_starting_server(
           }
         });
 
+      let mut proxied_tls_domains: HashMap<String, String> = HashMap::new();
       let mut tls_ports: HashMap<u16, CustomSniResolver> = HashMap::new();
       #[allow(clippy::type_complexity)]
       let mut tls_port_locks: HashMap<u16, Arc<tokio::sync::RwLock<Vec<(String, Arc<dyn ResolvesServerCert>)>>>> =
@@ -453,6 +454,17 @@ fn before_starting_server(
           .unwrap_or(false);
 
         let https_port = server_configuration.filters.port.or(default_https_port);
+
+        // Check for a `proxy_tls` directive in the server configuration block
+        if let Some(proxied_tls_domain) = get_value!("proxy_tls", server_configuration) {
+          // Woops apparently this automatically adds 443 to the * block listened ports which is definitely not what we want
+          // but it works with globals so hey this is just a PoC
+          proxied_tls_domains.insert(
+            server_configuration.filters.hostname.clone().unwrap(),
+            proxied_tls_domain.as_str().unwrap().to_string(),
+          );
+          tls_ports.insert(https_port.unwrap_or(443), CustomSniResolver::new());
+        }
 
         let sni_hostname = server_configuration.filters.hostname.clone().or_else(|| {
           // !!! UNTESTED, many clients don't send SNI hostname when accessing via IP address anyway
@@ -1444,6 +1456,7 @@ fn before_starting_server(
           acme_tls_alpn_01_configs.clone(),
           acme_http_01_resolvers.clone(),
           enable_proxy_protocol,
+          proxied_tls_domains.clone(),
         )?);
       }
 


### PR DESCRIPTION
This is really bad code and does everything very wrong, sorry about that, it's just a proof-of-concept. I just submitted this because it took me a while to figure it out already, and people seemed interested in #58 (5 upvotes at the time of writing).

Supports:

- [x] tokio runtime
- [ ] monoio runtime
- [x] TCP connections
- [ ] QUIC connections 

It's very quick & dirty, as it will peek in the stream to find the TLS handshake (i couldn't find a peek equivalent in monoio, so only tokio is supported for now), which will be parsed a second time if the connection is not reverse proxied without TLS termination.

Also, i mostly have no idea what i'm doing with that backend `TcpStream` reading/writing, i just hacked this around, but i'm guessing it's possible to pipe actual `tcp_stream` into `dest_stream` without dark magic (i just don't know how).

# Testing

It's using the `proxy_tls` directive in vhosts. For example:

```
google.com:4443 {
  proxy_tls "142.250.178.131:443"
}
```

Now you can curl it:

```
curl -v -4 --connect-to 'google.com:443:127.0.0.1:4443' https://google.com
```

# Additional notes

- it's very cumbersome to get SNI from `rustls` without consuming the connection (hence the peeked buffer hack), there's plenty of issues about it upstream, and i don't understand why the maintainers don't want to make it easier (i had to fork rustls to make more types public, but there may be a simpler way)