### PR TITLE
[installer] fix(service): supports busybox `ps`

### DIFF
--- a/installer/install-template.sh
+++ b/installer/install-template.sh
@@ -451,49 +451,63 @@ echo_warning() {
     echo -n "warning"
 }
 
+is_busybox_ps() {
+    ps --help 2>&1 | grep -qi busybox
+}
+
+get_pids() {
+    if type ps > /dev/null 2>&1; then
+        if is_busybox_ps; then
+            # BusyBox ps: PID is column 1
+            ps | grep "$server $serverargs" | grep -v grep | awk '{print $1}'
+        else
+            # procps ps
+            ps -aef | grep "$server $serverargs" | grep -v grep | awk '{print $2}'
+        fi
+    else
+        pidof $server
+    fi
+}
+
 do_stop()
 {
     echo -n $"Stopping $servicename: "
-    if type ps > /dev/null 2>&1; then
-      pid=`ps -aef | grep "$server $serverargs" | grep -v " grep " | awk '{print $2}' | xargs`
-    else
-      pid=`pidof $server | xargs`
-    fi
-    kill -9 $pid > /dev/null 2>&1 && echo_success || echo_failure
-    RETVAL=$?
-    echo
-    [ $RETVAL -eq 0 ] && rm -f "$lockfile"
+    pid="$(get_pids | xargs)"
 
-    if [ "$pid" = "" -a -f "$lockfile" ]; then
-        rm -f "$lockfile"
-        echo "Removed lockfile ( $lockfile )"
+    if [ -n "$pid" ]; then
+        kill -9 $pid >/dev/null 2>&1 \
+            && echo_success || echo_failure
+        RETVAL=$?
+    else
+        echo_warning
+        RETVAL=0
     fi
+
+    echo
+    rm -f "$lockfile"
 }
 
 do_reload()
 {
-    echo -n $"Reloading $servicename: "
-    if type ps > /dev/null 2>&1; then
-      pid=`ps -aef | grep "$server $serverargs" | grep -v " grep " | awk '{print $2}' | xargs`
+    echo -n "Reloading $servicename: "
+    pid="$(get_pids | xargs)"
+
+    if [ -n "$pid" ]; then
+        kill -HUP $pid >/dev/null 2>&1 && echo_success || echo_failure
     else
-      pid=`pidof $server | xargs`
+        echo_failure
     fi
-    kill -1 $pid > /dev/null 2>&1 && echo_success || echo_failure
     echo
 }
 
-do_status()
-{
-   if type ps > /dev/null 2>&1; then
-     pid=`ps -aef | grep "$server $serverargs" | grep -v " grep " | awk '{print $2}' | head -n 1`
-   else
-     pid=`pidof -s $server`
-   fi
-   if [ "$pid" != "" ]; then
-     echo "$servicename (pid $pid) is running..."
-   else
-     echo "$servicename is stopped"
-   fi
+do_status() {
+    pid="$(get_pids | head -n 1)"
+
+    if [ -n "$pid" ]; then
+        echo "$servicename (pid $pid) is running..."
+    else
+        echo "$servicename is stopped"
+    fi
 }
 
 case "$1" in


### PR DESCRIPTION
This PR fixes `service ferron status`, `service ferron reload` and `service ferron stop` being broken in an environment where BusyBox's `ps` is being used by default (Alpine Linux).

The PR also abstracts statements that gets ferron PIDs into 1 function `get_pids()`

## Explanation

The main issue that breaks service functions is BusyBox `ps` outputting PIDs in column 1 instead of 2. 
<details>
<summary>Example of BusyBox `ps` output</summary>

```
root@rprox ~# ps
PID   USER     TIME  COMMAND
    1 root      0:00 /sbin/init
    2 root      0:01 [kthreadd]
    3 root      0:00 [pool_workqueue_]
    4 root      0:00 [kworker/R-rcu_g]
    5 root      0:00 [kworker/R-sync_]
    6 root      0:00 [kworker/R-kvfre]
    7 root      0:00 [kworker/R-slub_]
    8 root      0:00 [kworker/R-netns]
   13 root      0:00 [kworker/R-mm_pe]
   15 root     12:43 [ksoftirqd/0]
   16 root     22:22 [rcu_preempt]
   17 root      0:00 [rcu_exp_par_gp_]
   18 root      0:09 [rcu_exp_gp_kthr]
```

</details>

<details>
<summary>Example of procps `ps` output</summary>

```
root@rprox ~# ps -aef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0  2025 ?        00:00:00 /sbin/init
root         2     0  0  2025 ?        00:00:01 [kthreadd]
root         3     2  0  2025 ?        00:00:00 [pool_workqueue_release]
root         4     2  0  2025 ?        00:00:00 [kworker/R-rcu_gp]
root         5     2  0  2025 ?        00:00:00 [kworker/R-sync_wq]
root         6     2  0  2025 ?        00:00:00 [kworker/R-kvfree_rcu_reclaim]
root         7     2  0  2025 ?        00:00:00 [kworker/R-slub_flushwq]
root         8     2  0  2025 ?        00:00:00 [kworker/R-netns]
root        13     2  0  2025 ?        00:00:00 [kworker/R-mm_percpu_wq]
root        15     2  0  2025 ?        00:12:43 [ksoftirqd/0]
root        16     2  0  2025 ?        00:22:23 [rcu_preempt]
root        17     2  0  2025 ?        00:00:00 [rcu_exp_par_gp_kthread_worker/0]
root        18     2  0  2025 ?        00:00:09 [rcu_exp_gp_kthread_worker]
```

</details>

By detecting if we're using BusyBox `ps` via `ps --help | grep busybox`, we can conditionally choose to take the first or second column.