### PR TITLE
fixed chmod in rpm packaging

### DIFF
--- a/packaging/rpm/ferron-template.spec
+++ b/packaging/rpm/ferron-template.spec
@@ -54,8 +54,10 @@ if [ ! -e /var/www/ferron/index.html ]; then
 fi
 
 chown -R ferron:ferron /var/log/ferron /var/lib/ferron /var/www/ferron
-chmod -R 755 /var/log/ferron /var/www/ferron
-chmod -R 644 /var/log/ferron/* /var/www/ferron/* 2>/dev/null || true
+find /var/www/ferron/* -type f -exec chmod 644 {} \;
+find /var/www/ferron/* -type d -exec chmod 755 {} \;
+find /var/log/ferron/* -type f -exec chmod 644 {} \;
+find /var/log/ferron/* -type d -exec chmod 755 {} \;
 
 # TODO: proper SELinux support
 if type restorecon >/dev/null 2>&1; then


### PR DESCRIPTION
Rpm packaging removed the execute rights (`x`) from `/var/log/ferron/*` and `/var/www/ferron/*`.
This leads to directories not being traversable and ferron serving a 403, permission denied. Thus, on an update it kills existing websites on rpm-based systems.

This PR should fix this issue. Please check the code.