### PR TITLE
Add `cargo audit` in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,3 +84,17 @@ jobs:
 
       - name: Check for unused dependencies
         run: cargo shear
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install "cargo audit"
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall --no-confirm cargo-audit --force
+
+      - name: Check for vulnerable dependencies
+        run: cargo audit


### PR DESCRIPTION
This pull request would add `cargo audit` to CI/CD workflows to automatically check for vulnerable dependencies in Ferron 3 and to make sure dependency-related vulnerabilities don't enter Ferron 3.