### PR TITLE
Fix TLS certificate resolution falling back to domain level higher even if not wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ If you are upgrading to this beta version, you must update your configuration fi
 - Fixed a bug where case-insensitive HTTP cache control directives were not recognized correctly.
 - Fixed a bug where CONNECT requests with authority-form URIs were erroneously blocked by the URL canonicalizer.
 - Fixed a bug where HTTP timeout durations were not being respected correctly.
+- Fixed a bug where TLS certificate resolver from domain name level higher (non-wildcard) was incorrectly used for TLS handshakes if the one from the domain name level matching the requested SNI isn't present.
 - Fixed HTTP-to-HTTPS redirects to correctly target the original requested URL rather than internal rewritten URLs.
 
 #### Observability

--- a/modules/http-server/src/server/mod.rs
+++ b/modules/http-server/src/server/mod.rs
@@ -379,15 +379,11 @@ impl BasicHttpModule {
                         ip,
                         host,
                         http_connection_options.clone(),
-                        false,
                     );
                 }
                 (Some(host), None) => {
-                    http_connection_options_resolver.insert_hostname(
-                        host,
-                        http_connection_options.clone(),
-                        false,
-                    );
+                    http_connection_options_resolver
+                        .insert_hostname(host, http_connection_options.clone());
                 }
                 (None, Some(ip)) => {
                     http_connection_options_resolver.insert_ip(ip, http_connection_options.clone());
@@ -510,15 +506,10 @@ impl BasicHttpModule {
                         (observability_provider, observability_block_arc);
                     match (&host_config.0.host, host_config.0.ip) {
                         (Some(host), Some(ip)) => {
-                            observability_resolver.insert_ip_and_hostname(
-                                ip,
-                                host,
-                                vec![entry],
-                                false,
-                            );
+                            observability_resolver.insert_ip_and_hostname(ip, host, vec![entry]);
                         }
                         (Some(host), None) => {
-                            observability_resolver.insert_hostname(host, vec![entry], false);
+                            observability_resolver.insert_hostname(host, vec![entry]);
                         }
                         (None, Some(ip)) => {
                             observability_resolver.insert_ip(ip, vec![entry]);
@@ -717,10 +708,10 @@ impl BasicHttpModule {
 
             match (&host_config.0.host, host_config.0.ip) {
                 (Some(host), Some(ip)) => {
-                    tls_resolver.insert_ip_and_hostname(ip, host, tls_resolver_sub, false);
+                    tls_resolver.insert_ip_and_hostname(ip, host, tls_resolver_sub);
                 }
                 (Some(host), None) => {
-                    tls_resolver.insert_hostname(host, tls_resolver_sub, false);
+                    tls_resolver.insert_hostname(host, tls_resolver_sub);
                 }
                 (None, Some(ip)) => {
                     tls_resolver.insert_ip(ip, tls_resolver_sub);

--- a/modules/http-server/src/server/sni/hostname_radix_tree.rs
+++ b/modules/http-server/src/server/sni/hostname_radix_tree.rs
@@ -6,6 +6,7 @@ struct HostnameRadixTreeMultiKey<'a>(Vec<Cow<'a, str>>);
 
 #[allow(clippy::non_canonical_partial_ord_impl)]
 impl<'a> PartialOrd for HostnameRadixTreeMultiKey<'a> {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         for i in 0..self.0.len().max(other.0.len()) {
             let self_element = self.0.get(i);
@@ -25,6 +26,7 @@ impl<'a> PartialOrd for HostnameRadixTreeMultiKey<'a> {
 }
 
 impl<'a> Ord for HostnameRadixTreeMultiKey<'a> {
+    #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // The `partial_cmp` method returns `None` if the keys are of different lengths,
         // but for the `Ord` trait we need to define a total order.
@@ -55,6 +57,7 @@ pub struct HostnameRadixTree<T> {
 
 impl<T> HostnameRadixTree<T> {
     /// Creates a new empty hostname radix tree
+    #[inline]
     pub fn new() -> Self {
         Self {
             root: HostnameRadixTreeNode {
@@ -66,6 +69,7 @@ impl<T> HostnameRadixTree<T> {
     }
 
     /// Inserts a configuration value into the tree based on the provided key
+    #[inline]
     pub fn insert(&mut self, matcher: String, value: T) {
         let mut key: Vec<Cow<'static, str>> = Vec::new();
         let mut is_wildcard = false;
@@ -176,6 +180,7 @@ impl<T> HostnameRadixTree<T> {
     }
 
     /// Obtains a reference to the configuration value associated with the provided multi-key, if it exists
+    #[inline]
     pub fn get<'a>(&'a self, hostname: &'a str) -> Option<&'a T> {
         let mut key: HostnameRadixTreeMultiKey<'a> = HostnameRadixTreeMultiKey(
             hostname

--- a/modules/http-server/src/server/sni/mod.rs
+++ b/modules/http-server/src/server/sni/mod.rs
@@ -2,3 +2,6 @@ mod hostname_radix_tree;
 mod tls;
 
 pub use tls::*;
+
+// Re-export HostnameRadixTree for sibling modules (e.g., tls_resolve)
+pub use hostname_radix_tree::HostnameRadixTree;

--- a/modules/http-server/src/server/tls_resolve.rs
+++ b/modules/http-server/src/server/tls_resolve.rs
@@ -2,429 +2,116 @@ use std::collections::BTreeMap;
 use std::net::IpAddr;
 use std::sync::Arc;
 
-/// Key types for the radix tree, ordered from root to leaf.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum RadixKey {
-    /// IPv4 address octet (e.g., `127` from `127.0.0.1`)
-    IpV4Octet(u8),
-    /// IPv6 address octet (e.g., first byte from `2001:db8::`)
-    IpV6Octet(u8),
-    /// Hostname segment (e.g., `"com"`, `"example"` from `"example.com"`)
-    HostSegment(String),
-    /// Hostname wildcard (`"*"` for `"*.example.com"`)
-    HostWildcard,
-}
+use crate::server::sni::HostnameRadixTree;
 
-impl RadixKey {
-    /// Converts the key to bytes for storage in the BTreeMap.
-    fn to_bytes(&self) -> Vec<u8> {
-        match self {
-            RadixKey::IpV4Octet(octet) => vec![0x00, *octet],
-            RadixKey::IpV6Octet(octet) => vec![0x01, *octet],
-            RadixKey::HostSegment(segment) => {
-                let mut bytes = vec![0x02];
-                bytes.extend_from_slice(segment.as_bytes());
-                bytes
-            }
-            RadixKey::HostWildcard => vec![0x03, b'*'],
-        }
-    }
-}
-
-/// A compressed radix tree node for generic data lookup.
-struct RadixNode<T> {
-    /// Compressed edge label leading to this node
-    edge: Vec<u8>,
-    /// Data stored at this node (if any)
-    data: Option<T>,
-    /// Child nodes (BTreeMap for ordered traversal)
-    children: BTreeMap<Vec<u8>, RadixNode<T>>,
-}
-
-impl<T> RadixNode<T> {
-    #[inline]
-    fn new(edge: Vec<u8>) -> Self {
-        Self {
-            edge,
-            data: None,
-            children: BTreeMap::new(),
-        }
-    }
-
-    #[inline]
-    fn with_data(edge: Vec<u8>, data: T) -> Self {
-        Self {
-            edge,
-            data: Some(data),
-            children: BTreeMap::new(),
-        }
-    }
-}
-
-/// A compressed radix tree for storing and looking up generic data.
+/// A simpler, hostname-centric radix tree used for TLS resolver lookups.
 ///
-/// The tree organizes data in a hierarchy:
-/// - Root level: Default/fallback data
-/// - First level: IPv4/IPv6 address octets
-/// - Second level: Hostname segments (reversed for suffix matching)
-/// - Third level: Wildcard entries
-///
-/// Usage: Build the tree using `insert_*` methods with `&mut self`,
-/// then use `lookup_*` methods with `&self` for concurrent reads.
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// use std::net::IpAddr;
-/// use std::sync::Arc;
-///
-/// // With Arc<dyn Trait>
-/// let mut tree: RadixTree<Arc<dyn TcpTlsResolver>> = RadixTree::new();
-/// tree.set_root_resolver(default_resolver.clone());
-/// tree.insert_ip(IpAddr::from([127, 0, 0, 1]), resolver.clone());
-///
-/// // With simple values
-/// let mut tree: RadixTree<String> = RadixTree::new();
-/// tree.set_root_data("default".to_string());
-/// tree.insert_hostname("example.com", "example".to_string(), false);
-/// ```
+/// This struct implements the public API previously provided by the compressed
+/// RadixTree but internally delegates hostname matching to
+/// `HostnameRadixTree` and keeps IP-only and IP+hostname maps to ensure exact
+/// semantics: an ip+hostname entry only matches that exact hostname (or its
+/// wildcard), and will not be returned for subdomains unless a wildcard was
+/// installed.
+#[derive(Debug)]
 pub struct RadixTree<T> {
-    root: RadixNode<T>,
+    root_data: Option<T>,
+    ip_map: BTreeMap<IpAddr, T>,
+    host_tree: HostnameRadixTree<T>,
+    ip_host_trees: BTreeMap<IpAddr, HostnameRadixTree<T>>,
 }
 
 impl<T: Clone> RadixTree<T> {
-    /// Creates a new empty radix tree.
+    /// Create a new empty tree
     #[inline]
     pub fn new() -> Self {
         Self {
-            root: RadixNode::new(Vec::new()),
+            root_data: None,
+            ip_map: BTreeMap::new(),
+            host_tree: HostnameRadixTree::new(),
+            ip_host_trees: BTreeMap::new(),
         }
     }
 
     /// Sets the root (default) data.
-    ///
-    /// This data is returned as a fallback when no other match is found.
+    #[inline]
     pub fn set_root_data(&mut self, data: T) {
-        self.root.data = Some(data);
+        self.root_data = Some(data);
     }
 
     /// Gets the root (default) data, if set.
     #[inline]
     pub fn root_data(&self) -> Option<T> {
-        self.root.data.clone()
-    }
-
-    /// Inserts data into the tree at the specified path.
-    ///
-    /// The path components are ordered from root to leaf:
-    /// - For IP-based: `[IpOctet(127), IpOctet(0), IpOctet(0), IpOctet(1)]`
-    /// - For hostname: `[HostSegment("com"), HostSegment("example")]` (reversed)
-    /// - For wildcard: `[HostWildcard, HostSegment("com"), HostSegment("example")]`
-    /// - For combined IP+hostname: IP octets followed by hostname segments
-    pub fn insert(&mut self, path: &[RadixKey], data: T) {
-        let mut current = &mut self.root;
-
-        for (i, key) in path.iter().enumerate() {
-            let bytes = key.to_bytes();
-            let is_last = i == path.len() - 1;
-
-            let child = {
-                let mut found_child_key = None;
-
-                // Find a child with matching edge prefix
-                for child_key in current.children.keys() {
-                    if child_key.starts_with(&bytes) || bytes.starts_with(child_key.as_slice()) {
-                        found_child_key = Some(child_key.clone());
-                        break;
-                    }
-                }
-
-                if let Some(child_key) = found_child_key {
-                    let child = current.children.get_mut(&child_key).unwrap();
-                    let child_edge = child.edge.clone();
-
-                    if child_edge == bytes {
-                        // Exact match - update data if this is the last segment
-                        if is_last {
-                            child.data = Some(data.clone());
-                        }
-                        child
-                    } else if child_edge.starts_with(&bytes) {
-                        // New node is a prefix of existing child - split
-                        let remaining = child_edge[bytes.len()..].to_vec();
-                        child.edge = bytes.clone();
-
-                        if is_last {
-                            child.data = Some(data.clone());
-                        }
-
-                        // Create new child for the remaining edge
-                        let existing_children = std::mem::take(&mut child.children);
-                        let new_child = RadixNode {
-                            edge: remaining.clone(),
-                            data: None,
-                            children: existing_children,
-                        };
-
-                        child.children.insert(remaining, new_child);
-                        child
-                    } else {
-                        // Existing child edge is a prefix of new bytes
-                        // Need to traverse deeper or create intermediate node
-                        let remaining = &bytes[child_edge.len()..];
-                        Self::insert_into_child(child, remaining, is_last, &data);
-                        child
-                    }
-                } else {
-                    // No matching child - create new node
-                    let new_node = if is_last {
-                        RadixNode::with_data(bytes.clone(), data.clone())
-                    } else {
-                        RadixNode::new(bytes.clone())
-                    };
-                    current.children.insert(bytes.clone(), new_node);
-                    current.children.get_mut(&bytes).unwrap()
-                }
-            };
-
-            current = child;
-        }
-    }
-
-    fn insert_into_child<'a>(
-        child: &'a mut RadixNode<T>,
-        remaining: &[u8],
-        is_last: bool,
-        data: &T,
-    ) -> &'a mut RadixNode<T> {
-        let mut current = child;
-        let mut offset = 0;
-
-        while offset < remaining.len() {
-            let edge = current.edge.clone();
-
-            if edge.is_empty() {
-                current.edge = remaining[offset..].to_vec();
-                if is_last && offset + edge.len() >= remaining.len() {
-                    current.data = Some(data.clone());
-                }
-                break;
-            }
-
-            // Find matching child or create new
-            let mut found = None;
-            for child_key in current.children.keys() {
-                if child_key.starts_with(&edge) || edge.starts_with(child_key.as_slice()) {
-                    found = Some(child_key.clone());
-                    break;
-                }
-            }
-
-            if let Some(child_key) = found {
-                let next_child = current.children.get_mut(&child_key).unwrap();
-                current = next_child;
-            } else {
-                let new_node = if is_last {
-                    RadixNode::with_data(remaining[offset..].to_vec(), data.clone())
-                } else {
-                    RadixNode::new(remaining[offset..].to_vec())
-                };
-                let edge_key = new_node.edge.clone();
-                current.children.insert(edge_key.clone(), new_node);
-                return current.children.get_mut(&edge_key).unwrap();
-            }
-
-            offset += edge.len();
-        }
-
-        current
-    }
-
-    /// Looks up data by path components.
-    ///
-    /// Returns the data at the highest (most specific) level found during traversal.
-    /// If no match is found and root data is set, returns the root data as fallback.
-    pub fn lookup(&self, path: &[RadixKey]) -> Option<T> {
-        let mut current = &self.root;
-        // Start with root data as the initial best match (fallback)
-        let mut best_match: Option<T> = self.root.data.clone();
-
-        for key in path {
-            let bytes = key.to_bytes();
-
-            let next = {
-                let mut found_child = None;
-
-                for (child_key, child) in &current.children {
-                    if child_key.as_slice() == bytes {
-                        found_child = Some((child, true));
-                        break;
-                    } else if bytes.starts_with(child_key.as_slice()) {
-                        // Partial match - continue traversal
-                        found_child = Some((child, false));
-                        break;
-                    }
-                }
-
-                if let Some((child, exact)) = found_child {
-                    // Check if this node has data
-                    if child.data.is_some() {
-                        best_match = child.data.clone();
-                    }
-
-                    if exact {
-                        Some(child)
-                    } else {
-                        // Partial match - continue with this child
-                        Some(child)
-                    }
-                } else {
-                    None
-                }
-            };
-
-            match next {
-                Some(child) => current = child,
-                None => break,
-            }
-        }
-
-        // Check final node for data
-        current.data.clone().or(best_match)
-    }
-
-    /// Converts an IP address to a path of IP octet keys.
-    fn ip_to_path(ip: IpAddr) -> Vec<RadixKey> {
-        match ip {
-            IpAddr::V4(addr) => addr
-                .octets()
-                .iter()
-                .copied()
-                .map(RadixKey::IpV4Octet)
-                .collect(),
-            IpAddr::V6(addr) => addr
-                .octets()
-                .iter()
-                .copied()
-                .map(RadixKey::IpV6Octet)
-                .collect(),
-        }
-    }
-
-    /// Converts a hostname to a path of hostname segment keys (reversed for suffix matching).
-    fn hostname_to_path(hostname: &str, wildcard: bool) -> Vec<RadixKey> {
-        let mut segments: Vec<RadixKey> = hostname
-            .split('.')
-            .rev()
-            .map(|s| RadixKey::HostSegment(s.to_string()))
-            .collect();
-
-        if wildcard {
-            segments.insert(0, RadixKey::HostWildcard);
-        }
-
-        segments
+        self.root_data.clone()
     }
 
     /// Inserts data for an IP address.
-    ///
-    /// For IPv4, all 4 octets are used. For IPv6, all 16 bytes are used.
+    #[inline]
     pub fn insert_ip(&mut self, ip: IpAddr, data: T) {
-        let path = Self::ip_to_path(ip);
-        self.insert(&path, data);
+        self.ip_map.insert(ip, data);
     }
 
     /// Inserts data for a hostname (with optional wildcard).
-    ///
-    /// If `wildcard` is true, the data will match `*.hostname`.
-    pub fn insert_hostname(&mut self, hostname: &str, data: T, wildcard: bool) {
-        let path = Self::hostname_to_path(hostname, wildcard);
-        self.insert(&path, data);
+    #[inline]
+    pub fn insert_hostname(&mut self, hostname: &str, data: T) {
+        self.host_tree.insert(hostname.to_string(), data);
     }
 
     /// Inserts data for both an IP address and hostname.
-    ///
-    /// This creates a more specific path: IP octets followed by hostname segments.
-    /// The data will only match when both the IP and hostname match.
-    ///
-    /// # Arguments
-    ///
-    /// * `ip` - IP address
-    /// * `hostname` - Hostname (e.g., `"localhost"`)
-    /// * `data` - The data to store
-    /// * `wildcard` - If true, matches subdomains (e.g., `*.example.com`)
-    pub fn insert_ip_and_hostname(&mut self, ip: IpAddr, hostname: &str, data: T, wildcard: bool) {
-        let mut path = Self::ip_to_path(ip);
-        path.extend(Self::hostname_to_path(hostname, wildcard));
-        self.insert(&path, data);
+    #[inline]
+    pub fn insert_ip_and_hostname(&mut self, ip: IpAddr, hostname: &str, data: T) {
+        let tree = self
+            .ip_host_trees
+            .entry(ip)
+            .or_insert_with(HostnameRadixTree::new);
+        tree.insert(hostname.to_string(), data);
     }
 
     /// Looks up data by IP address.
+    #[inline]
     pub fn lookup_ip(&self, ip: IpAddr) -> Option<T> {
-        let path = Self::ip_to_path(ip);
-        self.lookup(&path)
+        self.ip_map
+            .get(&ip)
+            .cloned()
+            .or_else(|| self.root_data.clone())
     }
 
     /// Looks up data by hostname.
-    ///
-    /// Attempts to find the most specific match, checking:
-    /// 1. Exact hostname match
-    /// 2. Wildcard match for parent domain
+    #[inline]
     pub fn lookup_hostname(&self, hostname: &str) -> Option<T> {
-        // Try exact match first
-        let exact_path = Self::hostname_to_path(hostname, false);
-        if let Some(data) = self.lookup(&exact_path) {
-            return Some(data);
-        }
-
-        // Try wildcard match (add "*" at the beginning of reversed segments)
-        let wildcard_path = Self::hostname_to_path(hostname, true);
-        self.lookup(&wildcard_path)
+        self.host_tree
+            .get(hostname)
+            .cloned()
+            .or_else(|| self.root_data.clone())
     }
 
     /// Looks up data by both IP address and hostname.
     ///
-    /// Attempts to find the most specific match in this order:
-    /// 1. Exact IP + exact hostname match
-    /// 2. Exact IP + wildcard hostname match
-    /// 3. IP prefix + hostname match (falls back to IP-only or hostname-only)
-    ///
-    /// # Arguments
-    ///
-    /// * `ip` - IP address
-    /// * `hostname` - Hostname to match (e.g., `"localhost"`)
-    ///
-    /// # Returns
-    ///
-    /// The most specific data found, or `None` if no match.
+    /// Order of precedence:
+    /// 1. ip-specific hostname exact/wildcard
+    /// 2. ip-only entry
+    /// 3. hostname-only entry (including wildcard)
+    /// 4. root data fallback
+    #[inline]
     pub fn lookup_ip_and_hostname(&self, ip: IpAddr, hostname: &str) -> Option<T> {
-        // Build full path: IP octets + hostname segments
-        let mut full_path = Self::ip_to_path(ip);
-        full_path.extend(Self::hostname_to_path(hostname, false));
-
-        // Try exact IP + exact hostname
-        if let Some(data) = self.lookup(&full_path) {
-            return Some(data);
+        // 1) ip-specific hostname tree
+        if let Some(tree) = self.ip_host_trees.get(&ip) {
+            if let Some(v) = tree.get(hostname) {
+                return Some(v.clone());
+            }
         }
 
-        // Try exact IP + wildcard hostname
-        let mut wildcard_path = Self::ip_to_path(ip);
-        wildcard_path.extend(Self::hostname_to_path(hostname, true));
-        if let Some(data) = self.lookup(&wildcard_path) {
-            return Some(data);
+        // 2) ip-only
+        if let Some(v) = self.ip_map.get(&ip) {
+            return Some(v.clone());
         }
 
-        // Fall back to IP-only lookup
-        if let Some(data) = self.lookup_ip(ip) {
-            return Some(data);
-        }
-
-        // Fall back to hostname-only lookup
+        // 3) hostname-only (includes root_data fallback)
         self.lookup_hostname(hostname)
     }
 }
 
 impl<T: Clone> Default for RadixTree<T> {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }
@@ -457,7 +144,7 @@ mod tests {
     #[test]
     fn test_insert_and_lookup_hostname() {
         let mut tree = RadixTree::new();
-        tree.insert_hostname("example.com", "example-com".to_string(), false);
+        tree.insert_hostname("example.com", "example-com".to_string());
 
         let found = tree.lookup_hostname("example.com");
         assert!(found.is_some());
@@ -470,7 +157,7 @@ mod tests {
     #[test]
     fn test_wildcard_lookup() {
         let mut tree = RadixTree::new();
-        tree.insert_hostname("example.com", "wildcard-example-com".to_string(), true);
+        tree.insert_hostname("*.example.com", "wildcard-example-com".to_string());
 
         let found = tree.lookup_hostname("sub.example.com");
         assert!(found.is_some());
@@ -481,8 +168,8 @@ mod tests {
     fn test_hierarchy_priority() {
         let mut tree = RadixTree::new();
 
-        tree.insert_hostname("com", "com-resolver".to_string(), false);
-        tree.insert_hostname("example.com", "example-com-resolver".to_string(), false);
+        tree.insert_hostname("com", "com-resolver".to_string());
+        tree.insert_hostname("example.com", "example-com-resolver".to_string());
 
         let found = tree.lookup_hostname("example.com");
         assert!(found.is_some());
@@ -497,7 +184,7 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             "ip-127".to_string(),
         );
-        tree.insert_hostname("localhost", "localhost".to_string(), false);
+        tree.insert_hostname("localhost", "localhost".to_string());
 
         assert!(tree
             .lookup_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
@@ -509,9 +196,9 @@ mod tests {
     fn test_btree_ordering() {
         let mut tree = RadixTree::new();
 
-        tree.insert_hostname("z.com", "z-resolver".to_string(), false);
-        tree.insert_hostname("a.com", "a-resolver".to_string(), false);
-        tree.insert_hostname("m.com", "m-resolver".to_string(), false);
+        tree.insert_hostname("z.com", "z-resolver".to_string());
+        tree.insert_hostname("a.com", "a-resolver".to_string());
+        tree.insert_hostname("m.com", "m-resolver".to_string());
 
         assert!(tree.lookup_hostname("z.com").is_some());
         assert!(tree.lookup_hostname("a.com").is_some());
@@ -522,7 +209,7 @@ mod tests {
     fn test_insert_ip_and_hostname() {
         let mut tree = RadixTree::new();
         let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        tree.insert_ip_and_hostname(ip, "localhost", "combined".to_string(), false);
+        tree.insert_ip_and_hostname(ip, "localhost", "combined".to_string());
 
         let found = tree.lookup_ip_and_hostname(ip, "localhost");
         assert!(found.is_some());
@@ -539,11 +226,25 @@ mod tests {
     fn test_ip_and_hostname_with_wildcard() {
         let mut tree = RadixTree::new();
         let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-        tree.insert_ip_and_hostname(ip, "example.com", "wildcard".to_string(), true);
+        tree.insert_ip_and_hostname(ip, "*.example.com", "wildcard".to_string());
 
         let found = tree.lookup_ip_and_hostname(ip, "sub.example.com");
         assert!(found.is_some());
         assert_eq!(found.unwrap(), "wildcard");
+    }
+
+    #[test]
+    fn test_ip_and_hostname_without_wildcard() {
+        let mut tree = RadixTree::new();
+        let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        tree.insert_ip_and_hostname(ip, "example.com", "exact".to_string());
+
+        let found = tree.lookup_ip_and_hostname(ip, "example.com");
+        assert!(found.is_some());
+        assert_eq!(found.unwrap(), "exact");
+
+        let not_found = tree.lookup_ip_and_hostname(ip, "sub.example.com");
+        assert!(not_found.is_none());
     }
 
     #[test]
@@ -552,7 +253,7 @@ mod tests {
 
         let ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
         tree.insert_ip(ip, "ip-only".to_string());
-        tree.insert_hostname("example.com", "hostname-only".to_string(), false);
+        tree.insert_hostname("example.com", "hostname-only".to_string());
 
         let found = tree.lookup_ip_and_hostname(ip, "example.com");
         assert!(found.is_some());
@@ -565,8 +266,8 @@ mod tests {
         let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
         let ip_prefix = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0));
         tree.insert_ip(ip_prefix, "ip-resolver".to_string());
-        tree.insert_hostname("example.com", "hostname-resolver".to_string(), false);
-        tree.insert_ip_and_hostname(ip, "example.com", "combined-resolver".to_string(), false);
+        tree.insert_hostname("example.com", "hostname-resolver".to_string());
+        tree.insert_ip_and_hostname(ip, "example.com", "combined-resolver".to_string());
 
         let found = tree.lookup_ip_and_hostname(ip, "example.com");
         assert!(found.is_some());


### PR DESCRIPTION
This pull request would fix TLS certificate resolution falling back to a domain level higher, even if the "domain level higher" isn't a wildcard one.

I saw the issue when there were TLS configurations for a main domain and a subdomain, but I removed the subdomain, and when I tried accessing the subdomain, instead of no certificate, I saw a certificate intended for the main domain served for the subdomain...

Also, the pull request fixes a possible issue with wildcard host matchers not being effective.