### PR TITLE
[Ferron 3] Replace `fancy-regex` with linear-time `regex`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 **Not yet released**
 
+### Breaking changes
+
+#### HTTP server core
+
+- **Linear-time regular expression engine**: The regular expression engine used by Ferron has been replaced by one using a linear-time algorithm, which means that backtracking regex patterns are no longer supported. This change was made to avoid potential ReDoS and catastrophic backtracking issues. If you are using syntax such as `(?= ...)`, `(?! ...)`, `(?<= ...)`, `(?<! ...)`, or `\1`, you need to rewrite the regexes.
+
 ### Added
 
 #### CLI utilities

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,21 +358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec 0.8.0",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,17 +1034,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fancy-regex"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "fastbloom"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,12 +1486,12 @@ version = "3.0.0-beta.9"
 dependencies = [
  "async-trait",
  "bytes",
- "fancy-regex",
  "ferron-core",
  "ferron-http",
  "ferron-observability",
  "http",
  "http-body-util",
+ "regex",
  "tokio",
 ]
 
@@ -1604,12 +1578,12 @@ dependencies = [
  "bytes",
  "cidr",
  "dashmap",
- "fancy-regex",
  "ferron-core",
  "ferron-http",
  "ferron-observability",
  "http",
  "http-body-util",
+ "regex",
  "rustc-hash",
  "tokio",
  "zincio-http",
@@ -1622,12 +1596,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "dashmap",
- "fancy-regex",
  "ferron-core",
  "ferron-http",
  "ferron-observability",
  "http",
  "http-body-util",
+ "parking_lot",
+ "regex",
  "rustc-hash",
  "tokio",
  "zincio",
@@ -1662,7 +1637,6 @@ dependencies = [
  "bytes",
  "chrono",
  "cidr",
- "fancy-regex",
  "ferron-core",
  "ferron-http",
  "ferron-observability",
@@ -1674,6 +1648,7 @@ dependencies = [
  "ppp",
  "quinn",
  "rand 0.10.2",
+ "regex",
  "rustc-hash",
  "rustls",
  "smallvec",
@@ -1736,12 +1711,12 @@ version = "3.0.0-beta.9"
 dependencies = [
  "async-trait",
  "bytes",
- "fancy-regex",
  "ferron-core",
  "ferron-http",
  "ferron-observability",
  "http",
  "http-body-util",
+ "regex",
  "tokio",
 ]
 
@@ -5892,7 +5867,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
- "bit-vec 0.9.1",
+ "bit-vec",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,7 +1601,6 @@ dependencies = [
  "ferron-observability",
  "http",
  "http-body-util",
- "parking_lot",
  "regex",
  "rustc-hash",
  "tokio",

--- a/docs/configuration/routing/rewrite.md
+++ b/docs/configuration/routing/rewrite.md
@@ -103,7 +103,17 @@ URL rewritten from "/old-path/users" to "/new-path/users"
 
 ## Regex syntax
 
-The regular expression engine used is [`fancy-regex`](https://crates.io/crates/fancy-regex), which supports most PCRE-like features including lookahead, lookbehind, and non-capturing groups. The matching is case-insensitive on Windows and case-sensitive on other platforms.
+The regular expression engine used is [`regex`](https://crates.io/crates/regex), which executes regular expressions in linear time (no support for backtracking). This means that regular expressions are executed efficiently without backtracking, mitigating potential ReDoS and catastrophic backtracking attacks.
+
+However, this also means you cannot use syntax listed below:
+
+- Lookahead statements (`(?= ...)`, `(?! ...)`)
+- Lookbehind statements (`(?<= ...)`, `(?<! ...)`)
+- Backreferences to capture groups (`\1`)
+
+If you have to negate a condition, you can use negated variants of some directives, such as `if_not` blocks instead of `if`, or `!~` in matchers instead of `~`.
+
+The matching is case-insensitive on Windows and case-sensitive on other platforms.
 
 ## Observability
 

--- a/docs/migration/from-v2.md
+++ b/docs/migration/from-v2.md
@@ -444,6 +444,10 @@ example.com {
 
 Ferron strips the `/api` prefix from the request URL before proxying. The backend still receives `/api` from the proxy URL.
 
+### Backtracking regular expressions
+
+In Ferron 3, backtracking regex patterns (which could be used with Ferron 2) are no longer supported. If you were using syntax such as `(?= ...)`, `(?! ...)`, `(?<= ...)`, `(?<! ...)`, or `\1`, you need to rewrite the regexes.
+
 ### Handler execution order
 
 Ferron 3 processes directives in a more defined order:

--- a/e2e/tests/config/directives.rs
+++ b/e2e/tests/config/directives.rs
@@ -29,6 +29,10 @@ async fn test_host_configuration() {
         request.header.user-agent ~ "^somescanner(/|$)"
       }
 
+      match NOT_BASIC_TXT {
+        request.uri.path != "/basic.txt"
+      }
+
       aunrel:80 {
         status 403
       }
@@ -49,9 +53,10 @@ async fn test_host_configuration() {
         }
 
         handle_error 404 {
-          status 302 {
-            regex r"^/(?!basic\.txt(?:$|[?#]))"
-            location "/basic.txt"
+          if NOT_BASIC_TXT {
+            status 302 {
+              location "/basic.txt"
+            }
           }
         }
       }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -190,21 +190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,17 +522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fancy-regex"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "fastbloom"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,7 +704,6 @@ dependencies = [
  "bytes",
  "chrono",
  "cidr",
- "fancy-regex",
  "ferron-core",
  "ferron-http",
  "ferron-observability",
@@ -742,6 +715,7 @@ dependencies = [
  "ppp",
  "quinn",
  "rand",
+ "regex",
  "rustc-hash",
  "rustls",
  "smallvec",

--- a/modules/http-map/Cargo.toml
+++ b/modules/http-map/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-fancy-regex = "0.19"
+regex = "1.13.1"
 http = "1"
 
 ferron-core = { path = "../../core" }

--- a/modules/http-map/src/config.rs
+++ b/modules/http-map/src/config.rs
@@ -4,9 +4,9 @@
 //! configuration into typed `MapRule` structures and evaluates them
 //! at request time to set destination variables.
 
-use fancy_regex::{Regex, RegexBuilder};
 use ferron_core::config::layer::LayeredConfiguration;
 use ferron_core::config::{ServerConfigurationBlock, ServerConfigurationDirectiveEntry, Variables};
+use regex::{Regex, RegexBuilder};
 
 /// A compiled mapping rule from configuration.
 #[derive(Debug, Clone)]
@@ -73,7 +73,7 @@ fn evaluate_entries(source: &str, entries: &[MapEntry], default: &Option<String>
     let mut best_wildcard_len = 0usize;
     for entry in entries {
         if let MapEntry::Wildcard { regex, .. } = entry {
-            if let Ok(true) = regex.is_match(source) {
+            if regex.is_match(source) {
                 let pattern_str = regex.as_str();
                 // Approximate: use regex pattern length as proxy for specificity
                 if pattern_str.len() > best_wildcard_len {
@@ -91,7 +91,7 @@ fn evaluate_entries(source: &str, entries: &[MapEntry], default: &Option<String>
 
     for entry in entries {
         if let MapEntry::Regex { regex, value } = entry {
-            if let Ok(Some(captures)) = regex.captures(source) {
+            if let Some(captures) = regex.captures(source) {
                 let resolved = resolve_captures(value, &captures);
                 return resolved;
             }
@@ -102,7 +102,7 @@ fn evaluate_entries(source: &str, entries: &[MapEntry], default: &Option<String>
 }
 
 /// Resolve capture group references ($1, $2, etc.) in the result value.
-fn resolve_captures(value: &str, captures: &fancy_regex::Captures<'_, str>) -> String {
+fn resolve_captures(value: &str, captures: &regex::Captures) -> String {
     let mut result = String::new();
     let mut chars = value.chars().peekable();
 

--- a/modules/http-map/src/validator.rs
+++ b/modules/http-map/src/validator.rs
@@ -1,8 +1,8 @@
-use fancy_regex::Regex;
 use ferron_core::config::validator::{
     entry_span, ConfigurationValidationError, ConfigurationValidator,
 };
 use ferron_core::config::{ServerConfigurationBlock, ServerConfigurationValue};
+use regex::Regex;
 
 /// Recognized sub-directives inside a `map { ... }` block.
 const MAP_BLOCK_DIRECTIVES: &[&str] = &["default", "exact", "regex"];

--- a/modules/http-response/Cargo.toml
+++ b/modules/http-response/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-fancy-regex = "0.19"
+regex = "1.13.1"
 cidr = "0.3"
 http = "1"
 http-body-util = "0.1.3"

--- a/modules/http-response/src/config.rs
+++ b/modules/http-response/src/config.rs
@@ -5,10 +5,10 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 use cidr::IpCidr;
-use fancy_regex::Regex;
 use ferron_core::config::layer::LayeredConfiguration;
 use ferron_core::config::ServerConfigurationValue;
 use ferron_http::HttpContext;
+use regex::Regex;
 
 use crate::ResponseEngine;
 

--- a/modules/http-response/src/stage.rs
+++ b/modules/http-response/src/stage.rs
@@ -27,7 +27,7 @@ const LOG_TARGET: &str = "ferron-http-response";
 
 /// Shared state for the http-response module.
 pub struct ResponseEngine {
-    pub compiled_regexes: DashMap<String, Arc<fancy_regex::Regex>, FxBuildHasher>,
+    pub compiled_regexes: DashMap<String, Arc<regex::Regex>, FxBuildHasher>,
 }
 
 impl ResponseEngine {
@@ -189,11 +189,11 @@ impl HttpResponseStage {
                 }
             }
             // Only regex: regex match
-            (None, Some(regex)) => regex.find(path).ok().flatten().map(|m| m.as_str()),
+            (None, Some(regex)) => regex.find(path).map(|m| m.as_str()),
             // Both url and regex: both must match
             (Some(url), Some(regex)) => {
                 if url == path {
-                    regex.find(path).ok().flatten().map(|m| m.as_str())
+                    regex.find(path).map(|m| m.as_str())
                 } else {
                     None
                 }

--- a/modules/http-response/src/validator.rs
+++ b/modules/http-response/src/validator.rs
@@ -123,7 +123,7 @@ impl ConfigurationValidator for HttpResponseValidator {
                             if let Some(regex_str) =
                                 regex_entry.args.first().and_then(|v| v.as_str())
                             {
-                                if fancy_regex::Regex::new(regex_str).is_err() {
+                                if regex::Regex::new(regex_str).is_err() {
                                     return Err(ConfigurationValidationError::from(format!(
                                         "Invalid `regex` — invalid regular expression: {regex_str}"
                                     ))

--- a/modules/http-rewrite/Cargo.toml
+++ b/modules/http-rewrite/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-fancy-regex = "0.19"
+regex = "1.13.1"
+parking_lot = "0.12"
 tokio = { version = "1", features = ["fs"] }
 http = "1"
 rustc-hash = "2"

--- a/modules/http-rewrite/Cargo.toml
+++ b/modules/http-rewrite/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 regex = "1.13.1"
-parking_lot = "0.12"
 tokio = { version = "1", features = ["fs"] }
 http = "1"
 rustc-hash = "2"

--- a/modules/http-rewrite/src/config.rs
+++ b/modules/http-rewrite/src/config.rs
@@ -7,9 +7,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use fancy_regex::{Regex, RegexBuilder};
 use ferron_core::config::layer::LayeredConfiguration;
 use ferron_core::config::{ServerConfigurationBlock, ServerConfigurationValue};
+use regex::{Regex, RegexBuilder};
 
 use crate::RewriteEngine;
 

--- a/modules/http-rewrite/src/lib.rs
+++ b/modules/http-rewrite/src/lib.rs
@@ -30,7 +30,7 @@ use crate::validator::RewriteValidator;
 
 /// Shared state for the http-response module.
 pub struct RewriteEngine {
-    pub compiled_regexes: DashMap<String, Arc<fancy_regex::Regex>, FxBuildHasher>,
+    pub compiled_regexes: DashMap<String, Arc<regex::Regex>, FxBuildHasher>,
 }
 
 impl RewriteEngine {

--- a/modules/http-rewrite/src/validator.rs
+++ b/modules/http-rewrite/src/validator.rs
@@ -49,7 +49,7 @@ impl RewriteValidator {
         // Compiling full regex just to validate it... :')
         if entry.args[0]
             .as_string_with_interpolations(&std::collections::HashMap::new())
-            .is_none_or(|ref re| fancy_regex::Regex::new(re).is_err())
+            .is_none_or(|ref re| regex::Regex::new(re).is_err())
         {
             return Err(ConfigurationValidationError::from(
                 "Invalid `rewrite` — the regular expression must be a valid regular expression string",

--- a/modules/http-server/Cargo.toml
+++ b/modules/http-server/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0.102"
 rustls = { version = "0.23.37", default-features = false, features = ["std"] }
 tokio-rustls = { version = "0.26.4", default-features = false }
 socket2 = "0.6.3"
-fancy-regex = "0.19"
+regex = "1.13.1"
 urlencoding = "2.1.3"
 ppp = "2.3.0"
 chrono = "0.4"

--- a/modules/http-server/src/config/resolver/matcher.rs
+++ b/modules/http-server/src/config/resolver/matcher.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
-use fancy_regex::Regex;
 use ferron_core::config::{
     ServerConfigurationMatcherExpr, ServerConfigurationMatcherOperand,
     ServerConfigurationMatcherOperator,
 };
 use ferron_http::variables::resolve_variable;
 use ferron_http::HttpContext;
+use regex::Regex;
 
 /// A matcher expression with pre-compiled regex patterns for efficient evaluation.
 ///
@@ -82,10 +82,10 @@ pub fn evaluate_matcher_condition(compiled_expr: &CompiledMatcherExpr, ctx: &Htt
         ServerConfigurationMatcherOperator::Regex => {
             if let Some(left) = left_val {
                 if let Some(regex) = &compiled_expr.compiled_regex {
-                    regex.is_match(&left).unwrap_or(false)
+                    regex.is_match(&left)
                 } else if let Some(right) = right_val {
                     match Regex::new(&right) {
-                        Ok(regex) => regex.is_match(&left).unwrap_or(false),
+                        Ok(regex) => regex.is_match(&left),
                         Err(_) => false,
                     }
                 } else {
@@ -98,10 +98,10 @@ pub fn evaluate_matcher_condition(compiled_expr: &CompiledMatcherExpr, ctx: &Htt
         ServerConfigurationMatcherOperator::NotRegex => {
             if let Some(left) = left_val {
                 if let Some(regex) = &compiled_expr.compiled_regex {
-                    !regex.is_match(&left).unwrap_or(false)
+                    !regex.is_match(&left)
                 } else if let Some(right) = right_val {
                     match Regex::new(&right) {
-                        Ok(regex) => !regex.is_match(&left).unwrap_or(false),
+                        Ok(regex) => !regex.is_match(&left),
                         Err(_) => true,
                     }
                 } else {

--- a/modules/http-variables/Cargo.toml
+++ b/modules/http-variables/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-fancy-regex = "0.19"
+regex = "1.13.1"
 
 ferron-core = { path = "../../core" }
 ferron-http = { path = "../../types/http" }

--- a/modules/http-variables/src/config.rs
+++ b/modules/http-variables/src/config.rs
@@ -1,11 +1,11 @@
 //! Configuration parsing for the `set_var` and `log_field` directives.
 
-use fancy_regex::{Regex, RegexBuilder};
 use ferron_core::config::layer::LayeredConfiguration;
 use ferron_core::config::{
     ServerConfigurationBlock, ServerConfigurationDirectiveEntry, ServerConfigurationValue,
     Variables,
 };
+use regex::{Regex, RegexBuilder};
 
 /// A compiled `set_var` rule from configuration.
 #[derive(Debug, Clone)]
@@ -149,7 +149,7 @@ pub fn evaluate_set_var_rules(
     let mut results = Vec::new();
     for rule in rules {
         let source_value = variables.resolve(&rule.source).unwrap_or_default();
-        let matched = rule.pattern.is_match(&source_value).unwrap_or(false);
+        let matched = rule.pattern.is_match(&source_value);
         if rule.negate != matched {
             results.push((rule.variable.clone(), rule.value.clone()));
         }

--- a/modules/http-variables/src/validator.rs
+++ b/modules/http-variables/src/validator.rs
@@ -66,7 +66,7 @@ impl VariablesValidator {
         }
 
         if let ServerConfigurationValue::String(pattern, span) = &entry.args[1] {
-            if let Err(e) = fancy_regex::Regex::new(pattern) {
+            if let Err(e) = regex::Regex::new(pattern) {
                 return Err(ConfigurationValidationError::from(format!(
                     "Invalid `set_var` — failed to compile regular expression: {e}"
                 ))

--- a/utils/kdl2ferron/src/translate.rs
+++ b/utils/kdl2ferron/src/translate.rs
@@ -1151,6 +1151,12 @@ pub fn process_block(
                                 }
                                 "regex" => {
                                     if let kdlite::dom::Value::String(s) = &entry.value {
+                                        if is_backtracking_regex(&s) {
+                                            diagnostics.todo(format!(
+                                                "Directive 'status' may not work correctly, \
+                                                as it uses backtracking regex syntax.",
+                                            ));
+                                        }
                                         status_block.statements.push(
                                             ferronconf::Statement::Directive(
                                                 ferronconf::Directive {
@@ -3250,6 +3256,14 @@ pub fn process_block(
                                     .ok_or_else(|| {
                                         anyhow::anyhow!("right operand is not a string")
                                     })?;
+                                if let ferronconf::Operand::String(r, _) = &right {
+                                    if is_backtracking_regex(r) {
+                                        diagnostics.todo(format!(
+                                            "Condition 'if_regex' may not work correctly, \
+                                        as it uses backtracking regex syntax.",
+                                        ));
+                                    }
+                                }
                                 ferron3_conditions.push(ferronconf::MatcherExpression {
                                     left,
                                     right,
@@ -3327,6 +3341,14 @@ pub fn process_block(
                                     .ok_or_else(|| {
                                         anyhow::anyhow!("right operand is not a string")
                                     })?;
+                                if let ferronconf::Operand::String(r, _) = &right {
+                                    if is_backtracking_regex(r) {
+                                        diagnostics.todo(format!(
+                                            "Condition 'if_not_regex' may not work correctly, \
+                                        as it uses backtracking regex syntax.",
+                                        ));
+                                    }
+                                }
                                 ferron3_conditions.push(ferronconf::MatcherExpression {
                                     left,
                                     right,
@@ -4056,6 +4078,12 @@ pub fn process_block(
                 });
 
                 if let (Some(regex), Some(replacement)) = (regex, replacement) {
+                    if is_backtracking_regex(&regex) {
+                        diagnostics.todo(format!(
+                            "Directive 'rewrite' may not work correctly, \
+                            as it uses backtracking regex syntax.",
+                        ));
+                    }
                     let mut block = ferronconf::Block {
                         trailing_comments: HashMap::new(),
                         blank_lines_before: HashMap::new(),
@@ -4166,6 +4194,16 @@ pub fn process_block(
         statements,
         span: ferronconf::Span { line: 0, column: 0 },
     })
+}
+
+fn is_backtracking_regex(regex_str: &str) -> bool {
+    regex_str.contains("(?=")
+        || regex_str.contains("(?<")
+        || regex_str.contains("(?!")
+        || regex_str
+            .chars()
+            .zip(regex_str.chars().skip(1))
+            .any(|(ch1, ch2)| ch1 == '\\' && ch2.is_ascii_digit())
 }
 
 fn duration_kdl_to_ferron(duration: &kdlite::dom::Value) -> Option<ferronconf::Value> {


### PR DESCRIPTION
This pull request would replace `fancy-regex` crate with `regex` crate, which matches in linear-time (no backtracking).

This is to improve security by reducing ReDoS and catastrophic backtracking risks.

It's a breaking change, and breaks Ferron 2-derived and Ferron 3 configurations that uses backtracking (syntax like `(?= ...)`, `(?! ...)`, `(?<= ...)`, `(?<! ...)`), so I added a note in the documentation, breaking change note in the changelog and a TODO in `ferron-kdl2ferron`.

This is similar to Caddy, which uses Go's regular expression engine that executes regular expressions in linear time and accepts RE2 syntax.