### PR TITLE
feat: add OIDC authentication module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 **Not yet released**
 
+### Added
+
+- Added the `oidc` authentication module, implementing an OpenID Connect relying party with the authorization code flow and PKCE (works with providers like Authelia and Keycloak).
+
 ### Fixed
 
 - Fixed OCSP stapling not working properly for ECDSA issuer certificates.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +719,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +990,17 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
@@ -966,6 +1008,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -977,6 +1032,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -995,6 +1051,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1120,6 +1177,12 @@ dependencies = [
  "proptest",
  "serde_core",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -1262,12 +1325,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1287,6 +1363,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1327,6 +1464,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1367,7 +1516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1411,7 +1560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b70617312220ada56e308bf4a2287c942629ce36635204eb18faa74db2470514"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "hickory-net",
@@ -1441,10 +1590,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1517,7 +1731,7 @@ dependencies = [
  "async-channel",
  "aws-lc-rs",
  "backtrace",
- "base64",
+ "base64 0.22.1",
  "blocking",
  "bytes",
  "chrono",
@@ -1628,7 +1842,7 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-route53",
- "base64",
+ "base64 0.22.1",
  "dns-update",
  "ferron-common",
  "hyper",
@@ -1657,11 +1871,12 @@ dependencies = [
  "async-compression",
  "async-process",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cegla",
  "cegla-cgi",
  "cegla-scgi",
+ "chacha20poly1305",
  "chrono",
  "cidr",
  "fancy-regex",
@@ -1669,6 +1884,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "hashlink 0.12.1",
+ "hkdf",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -1676,10 +1892,15 @@ dependencies = [
  "monoio",
  "monoio-compat",
  "new_mime_guess",
+ "openidconnect",
  "password-auth",
  "pin-project-lite",
  "quick_cache 0.7.0",
+ "reqwest",
  "send_wrapper",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
  "shiba",
  "shlex",
  "smallvec",
@@ -1763,6 +1984,22 @@ dependencies = [
  "kdl",
  "yaml-rust2",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1923,6 +2160,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1989,6 +2227,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,7 +2249,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2034,6 +2283,12 @@ dependencies = [
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2172,6 +2427,15 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2326,7 +2590,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2451,6 +2715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,12 +2743,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2498,7 +2781,7 @@ checksum = "9f05ad37c421b962354c358d347d4a6130151df9407978372d3ad7f0c8f71a64"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http 1.5.0",
  "http-body 1.1.0",
@@ -2578,6 +2861,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2768,12 +3060,21 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin 0.9.9",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -3074,6 +3375,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3089,12 +3406,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3105,6 +3433,25 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http 1.5.0",
+ "rand 0.8.7",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -3146,6 +3493,43 @@ name = "oneshot"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openidconnect"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac 0.12.1",
+ "http 1.5.0",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256",
+ "p384",
+ "rand 0.8.7",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2 0.10.9",
+ "subtle",
+ "thiserror 1.0.69",
+ "url",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -3207,7 +3591,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3242,6 +3626,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +3645,30 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "parking"
@@ -3336,8 +3753,17 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -3390,6 +3816,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3407,6 +3854,17 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3469,6 +3927,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3507,7 +3974,7 @@ dependencies = [
  "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "unarray",
@@ -3666,11 +4133,22 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -3680,9 +4158,19 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.1",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3859,6 +4347,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3907,7 +4415,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "spin",
+ "spin 0.10.1",
  "thiserror 2.0.20",
  "url",
  "uuid",
@@ -3919,7 +4427,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "h2",
@@ -3964,6 +4472,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e61cd21fbddd85fbd9367b775660a01d388c08a61c6d2824af480b0309bb9"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3986,6 +4504,26 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4170,6 +4708,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4185,6 +4747,20 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4236,6 +4812,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4269,6 +4855,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4287,6 +4893,39 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4356,6 +4995,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4422,9 +5071,25 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -4795,7 +5460,7 @@ version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -4835,7 +5500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http 1.5.0",
  "http-body 1.1.0",
@@ -4884,7 +5549,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5016,6 +5681,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5037,6 +5712,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/docs/configuration/security-tls.md
+++ b/docs/configuration/security-tls.md
@@ -125,6 +125,57 @@ example.com {
 }
 ```
 
+### OpenID Connect authentication
+
+The directives below configure the `oidc` module (Ferron 2.9.0 or newer), which protects websites by authenticating users against an OpenID Connect provider (such as Authelia or Keycloak) using the authorization code flow with PKCE. The user's session is kept in an encrypted cookie, and identity request headers are provided to backend servers.
+
+- `auth_oidc <issuer_url: string>`
+  - This directive enables OpenID Connect authentication and specifies the OIDC issuer URL (without the `/.well-known/openid-configuration` suffix). The OIDC provider metadata is fetched through OpenID Connect Discovery. Default: none
+- `auth_oidc_client_id <client_id: string>`
+  - This directive specifies the OAuth2 client ID registered at the OIDC provider. Default: none
+- `auth_oidc_client_secret <client_secret: string>`
+  - This directive specifies the OAuth2 client secret. It's recommended to use an environment variable placeholder instead of writing the secret into the configuration file. Default: none
+- `auth_oidc_scopes <scope: string> [<scope: string> ...]`
+  - This directive specifies the requested scopes. Add the `"groups"` scope to receive the user's groups from OIDC providers that support it (such as Authelia). Default: `auth_oidc_scopes "openid" "profile" "email"`
+- `auth_oidc_cookie_secret <cookie_secret: string>`
+  - This directive specifies the Base64-encoded secret (at least 32 bytes after decoding) used to encrypt the session and state cookies. If not specified, a random secret is generated at server startup; sessions then don't survive server restarts and can't be shared between multiple server instances, so configuring this directive is strongly recommended. A secret can be generated with `openssl rand -base64 32`. Default: none (random secret)
+- `auth_oidc_cookie_name <cookie_name: string>`
+  - This directive specifies the session cookie name. The state cookie used during the login flow is named after the session cookie with a `_state` suffix. Default: `auth_oidc_cookie_name "ferron_oidc_session"`
+- `auth_oidc_session_ttl <session_ttl: integer>`
+  - This directive specifies the session time-to-live in seconds. Default: `auth_oidc_session_ttl 86400`
+- `auth_oidc_redirect_path <redirect_path: string>`
+  - This directive specifies the path of the OIDC callback (redirect URI) handled by Ferron. The full redirect URI registered at the OIDC provider is this path appended to the website's base URL. Default: `auth_oidc_redirect_path "/.ferron/oidc/callback"`
+- `auth_oidc_logout_path <logout_path: string|null>`
+  - This directive specifies a path that logs the user out by expiring the session cookie. If set as `auth_oidc_logout_path #null`, the logout path is disabled. Default: `auth_oidc_logout_path #null`
+- `auth_oidc_post_logout_redirect <post_logout_redirect: string>`
+  - This directive specifies the local path to redirect to after logging out. Default: `auth_oidc_post_logout_redirect "/"`
+- `auth_oidc_headers [inject_headers: bool]`
+  - This directive specifies whether the `Remote-User`, `Remote-Groups`, `Remote-Email`, and `Remote-Name` request headers are provided to backend servers for authenticated users. These headers are always removed from incoming client requests. Default: `auth_oidc_headers #true`
+- `auth_oidc_user_claim <user_claim: string>`
+  - This directive specifies the ID token claim used as the authenticated username (either `"preferred_username"`, `"email"`, or `"sub"`), with a fallback to other claims if the specified claim isn't present. Default: `auth_oidc_user_claim "preferred_username"`
+- `auth_oidc_allowed_groups <group: string> [<group: string> ...]`
+  - This directive restricts access to users belonging to at least one of the specified groups (determined from the `groups` ID token claim). If not specified, all authenticated users are allowed. Default: none
+- `auth_oidc_audience <audience: string> [<audience: string> ...]`
+  - This directive specifies additional accepted ID token audiences besides the client ID. Default: none
+- `auth_oidc_no_verification [no_verification: bool]`
+  - This directive specifies whether the server should not verify the TLS certificate of the OIDC provider. Default: `auth_oidc_no_verification #false`
+
+**Configuration example:**
+
+```kdl
+app.example.com {
+    auth_oidc "https://auth.example.com"
+    auth_oidc_client_id "ferron"
+    auth_oidc_client_secret "{env.FERRON_OIDC_CLIENT_SECRET}"
+    auth_oidc_scopes "openid" "profile" "email" "groups"
+    auth_oidc_cookie_secret "{env.FERRON_OIDC_COOKIE_SECRET}"
+    auth_oidc_logout_path "/.ferron/oidc/logout"
+    auth_oidc_allowed_groups "admins" "developers"
+
+    proxy "http://127.0.0.1:3000/"
+}
+```
+
 ## DNS providers for ACME DNS-01 challenge
 
 When using `auto_tls_challenge "dns-01"` directive, you can specify the DNS provider to be used for the ACME DNS-01 challenge with the `provider` prop. Below is the list of supported DNS providers and their additional configuration props.

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -15,6 +15,7 @@ The following modules are built into Ferron and are enabled by default:
 - _fproxy_ - this module enables forward proxy functionality.
 - _fproxyauth_ (Ferron 2.4.0 and newer) - this module enables forward proxy authentication via HTTP Basic authentication.
 - _limit_ (Ferron 2.0.0 and newer) - this module enables rate limits.
+- _oidc_ (Ferron 2.9.0 and newer) - this module enables authentication with an OpenID Connect provider.
 - _replace_ (Ferron 2.0.0 and newer) - this module enables replacement of strings in response bodies.
 - _rproxy_ - this module enables reverse proxy functionality.
 - _scgi_ - this module enables the support for connecting to SCGI servers.
@@ -64,6 +65,19 @@ If you are using the _fproxy_ module, then hosts on the local network and local 
 ### _limit_ module
 
 This module uses a Token Bucket algorithm. The rate limitation is on per-IP address basis.
+
+### _oidc_ module
+
+This module implements an OpenID Connect relying party using the authorization code flow with PKCE, comparable to tools like oauth2-proxy. It works with any spec-compliant OpenID Connect provider (for example Authelia or Keycloak). The user's identity is kept in an encrypted session cookie; no server-side session store is needed, so sessions work across multiple worker threads and (with a configured cookie secret) across multiple server instances.
+
+For authenticated users, the following request headers are provided to backend servers (the same headers used by Authelia's forward authentication):
+
+- **Remote-User** - the authenticated username
+- **Remote-Groups** - the user's groups (comma-separated)
+- **Remote-Email** - the user's email address
+- **Remote-Name** - the user's display name
+
+These headers are always removed from incoming client requests, so clients can't spoof them.
 
 ### _replace_ module
 

--- a/docs/use-cases/oidc-authentication.md
+++ b/docs/use-cases/oidc-authentication.md
@@ -1,0 +1,118 @@
+---
+title: OIDC authentication
+description: "Protect Ferron websites with single sign-on using an OpenID Connect provider like Authelia or Keycloak."
+---
+
+Ferron 2.9.0 and newer can act as an OpenID Connect relying party with the `oidc` module: users are authenticated against an OpenID Connect provider (such as Authelia, Keycloak, or any other spec-compliant provider) using the authorization code flow with PKCE, without adding authentication logic to your backend applications.
+
+When an unauthenticated user opens a protected website, Ferron redirects them to the OIDC provider's login page. After a successful login, the user is redirected back to Ferron, which verifies the ID token, stores the identity in an encrypted session cookie, and provides the `Remote-User`, `Remote-Groups`, `Remote-Email`, and `Remote-Name` request headers to backend servers.
+
+Unlike [forward authentication](/docs/use-cases/forward-auth) (the `fauth` module), the `oidc` module doesn't need a per-request round trip to the authentication service; the session is verified by Ferron itself.
+
+## Protect an app with Authelia
+
+Ferron configuration:
+
+```kdl
+app.example.com {
+    auth_oidc "https://auth.example.com"
+    auth_oidc_client_id "ferron"
+    auth_oidc_client_secret "{env.FERRON_OIDC_CLIENT_SECRET}"
+    auth_oidc_scopes "openid" "profile" "email" "groups"
+    auth_oidc_cookie_secret "{env.FERRON_OIDC_COOKIE_SECRET}"
+    auth_oidc_logout_path "/.ferron/oidc/logout"
+
+    proxy "http://127.0.0.1:3000/"
+}
+```
+
+Generate the cookie secret with `openssl rand -base64 32`, and generate the client secret and its hash with `authelia crypto hash generate pbkdf2 --random`.
+
+Authelia client registration (in Authelia's `configuration.yml`):
+
+```yaml
+identity_providers:
+  oidc:
+    clients:
+      - client_id: "ferron"
+        client_name: "Ferron"
+        client_secret: "$pbkdf2-sha512$310000$..." # The hashed client secret
+        public: false
+        authorization_policy: "one_factor"
+        require_pkce: true
+        pkce_challenge_method: "S256"
+        redirect_uris:
+          - "https://app.example.com/.ferron/oidc/callback"
+        scopes:
+          - "openid"
+          - "profile"
+          - "email"
+          - "groups"
+        token_endpoint_auth_method: "client_secret_basic"
+```
+
+## Protect an app with Keycloak
+
+Create a confidential client in your Keycloak realm ("Clients" → "Create client", "Client authentication" enabled) with the valid redirect URI `https://app.example.com/.ferron/oidc/callback`, then configure Ferron:
+
+```kdl
+app.example.com {
+    auth_oidc "https://keycloak.example.com/realms/myrealm"
+    auth_oidc_client_id "ferron"
+    auth_oidc_client_secret "{env.FERRON_OIDC_CLIENT_SECRET}"
+    auth_oidc_cookie_secret "{env.FERRON_OIDC_COOKIE_SECRET}"
+
+    proxy "http://127.0.0.1:3000/"
+}
+```
+
+To use group-based access control with Keycloak, add a "Group Membership" mapper (with full group paths disabled) that maps groups into a `groups` claim in the ID token.
+
+## Restrict access to specific groups
+
+```kdl
+app.example.com {
+    auth_oidc "https://auth.example.com"
+    auth_oidc_client_id "ferron"
+    auth_oidc_client_secret "{env.FERRON_OIDC_CLIENT_SECRET}"
+    auth_oidc_scopes "openid" "profile" "email" "groups"
+    auth_oidc_cookie_secret "{env.FERRON_OIDC_COOKIE_SECRET}"
+    auth_oidc_allowed_groups "admins" "developers"
+
+    proxy "http://127.0.0.1:3000/"
+}
+```
+
+Users that authenticate successfully but don't belong to any of the allowed groups receive a 403 Forbidden response.
+
+## Protect only selected paths
+
+Apply OIDC authentication only where needed:
+
+```kdl
+app.example.com {
+    // Public content (no authentication).
+    location "/public" {
+        root "/var/www/public"
+    }
+
+    // Everything else requires login.
+    location "/" {
+        auth_oidc "https://auth.example.com"
+        auth_oidc_client_id "ferron"
+        auth_oidc_client_secret "{env.FERRON_OIDC_CLIENT_SECRET}"
+        auth_oidc_cookie_secret "{env.FERRON_OIDC_COOKIE_SECRET}"
+        proxy "http://127.0.0.1:3000/"
+    }
+}
+```
+
+## Notes
+
+- The `/.ferron/oidc/callback` path (or the path configured with `auth_oidc_redirect_path`) is handled by Ferron itself and isn't passed to backend servers.
+- Requests that look like API calls (non-GET/HEAD methods, `Sec-Fetch-Mode: cors`, or `X-Requested-With` header) receive a 401 Unauthorized response instead of a redirect to the login page.
+- Always configure `auth_oidc_cookie_secret` in production; without it, a random secret is generated at startup, so sessions don't survive server restarts and can't be shared between multiple server instances.
+- The user's session lives in an encrypted cookie; Ferron doesn't store OAuth2 tokens. Refresh tokens and RP-initiated logout at the OIDC provider aren't supported yet.
+- Ensure that the clocks of Ferron and the OIDC provider are synchronized (for example with NTP), as ID token validation is time-sensitive.
+
+For the full directive reference, see the [configuration reference](/docs/configuration/security-tls#openid-connect-authentication).

--- a/e2e/images/backend/index.js
+++ b/e2e/images/backend/index.js
@@ -23,6 +23,10 @@ app.get("/header", (req, res, _next) => {
   res.send(req.headers["x-some-header"]);
 });
 
+app.get("/remote-user", (req, res, _next) => {
+  res.send(req.headers["remote-user"] || "");
+});
+
 app.get("/unsafe", (req, _res, _next) => {
   req.socket.destroy();
 });

--- a/e2e/tests/oidc.rs
+++ b/e2e/tests/oidc.rs
@@ -21,6 +21,8 @@ async fn create_mock_idp_container(network: &str) -> Result<ContainerAsync<Gener
         .with_port(ContainerPort::Tcp(8080))
         .with_response_matcher(|response| response.status().is_success()),
     )))
+    // Non-interactive login: the authorization endpoint redirects back with a code immediately
+    .with_env_var("JSON_CONFIG", r#"{"interactiveLogin": false}"#)
     .with_network(network)
     .with_hostname("mockidp")
     .start()

--- a/e2e/tests/oidc.rs
+++ b/e2e/tests/oidc.rs
@@ -1,0 +1,279 @@
+#[cfg(unix)]
+use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+use std::{io::Write, path::Path};
+
+use testcontainers::{
+  ContainerAsync, GenericImage, ImageExt, TestcontainersError,
+  core::{ContainerPort, Mount, WaitFor, wait::HttpWaitStrategy},
+  runners::AsyncRunner,
+};
+
+mod common;
+
+// 32 bytes, Base64-encoded
+const COOKIE_SECRET: &str = "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=";
+
+async fn create_mock_idp_container(network: &str) -> Result<ContainerAsync<GenericImage>, TestcontainersError> {
+  GenericImage::new("ghcr.io/navikt/mock-oauth2-server", "2.1.10")
+    .with_exposed_port(ContainerPort::Tcp(8080))
+    .with_wait_for(WaitFor::Http(Box::new(
+      HttpWaitStrategy::new("/default/.well-known/openid-configuration")
+        .with_port(ContainerPort::Tcp(8080))
+        .with_response_matcher(|response| response.status().is_success()),
+    )))
+    .with_network(network)
+    .with_hostname("mockidp")
+    .start()
+    .await
+}
+
+async fn create_backend_container(network: &str) -> Result<ContainerAsync<GenericImage>, TestcontainersError> {
+  let backend_image = self::common::build_backend_image().await?;
+  backend_image
+    .with_exposed_port(ContainerPort::Tcp(3000))
+    .with_wait_for(WaitFor::Http(Box::new(
+      HttpWaitStrategy::new("/")
+        .with_port(ContainerPort::Tcp(3000))
+        .with_response_matcher(|_| true),
+    )))
+    .with_network(network)
+    .with_hostname("backend")
+    .start()
+    .await
+}
+
+async fn create_ferron_container(
+  network: &str,
+  config_file: &Path,
+) -> Result<ContainerAsync<GenericImage>, TestcontainersError> {
+  let ferron_image = self::common::build_ferron_image().await?;
+  ferron_image
+    .with_exposed_port(ContainerPort::Tcp(80))
+    .with_wait_for(WaitFor::Http(Box::new(
+      HttpWaitStrategy::new("/")
+        .with_port(ContainerPort::Tcp(80))
+        .with_response_matcher(|_| true),
+    )))
+    .with_network(network)
+    .with_hostname("ferron")
+    .with_mount(Mount::bind_mount(
+      config_file.to_string_lossy().to_string(),
+      "/etc/ferron.kdl",
+    ))
+    .start()
+    .await
+}
+
+struct OidcTestContext {
+  _mock_idp: ContainerAsync<GenericImage>,
+  _backend: ContainerAsync<GenericImage>,
+  _ferron: ContainerAsync<GenericImage>,
+  base_url: String,
+  idp_base_url: String,
+  client: reqwest::Client,
+  _config_file: tempfile::NamedTempFile,
+}
+
+async fn setup(test_name: &str) -> OidcTestContext {
+  let _ = rustls::crypto::ring::default_provider().install_default();
+
+  let network = format!("e2e-test-oidc-{}", test_name);
+
+  let mock_idp = create_mock_idp_container(&network).await.unwrap();
+  let backend = create_backend_container(&network).await.unwrap();
+
+  #[cfg(unix)]
+  nix::sys::stat::umask(nix::sys::stat::Mode::from_bits(0o000).unwrap());
+
+  #[cfg(unix)]
+  let mut config_file = tempfile::Builder::new()
+    .permissions(Permissions::from_mode(0o666))
+    .tempfile()
+    .unwrap();
+  #[cfg(not(unix))]
+  let mut config_file = tempfile::NamedTempFile::new().unwrap();
+
+  config_file
+    .as_file_mut()
+    .write_all(
+      format!(
+        r#"
+:80 {{
+  auth_oidc "http://mockidp:8080/default"
+  auth_oidc_client_id "ferron-e2e"
+  auth_oidc_client_secret "e2e-secret"
+  auth_oidc_cookie_secret "{COOKIE_SECRET}"
+  auth_oidc_logout_path "/oidc-logout"
+
+  proxy "http://backend:3000"
+}}
+"#
+      )
+      .as_bytes(),
+    )
+    .unwrap();
+
+  let ferron = create_ferron_container(&network, config_file.path()).await.unwrap();
+
+  let ferron_port = ferron.get_host_port_ipv4(ContainerPort::Tcp(80)).await.unwrap();
+  let idp_port = mock_idp.get_host_port_ipv4(ContainerPort::Tcp(8080)).await.unwrap();
+
+  let client = reqwest::Client::builder()
+    .redirect(reqwest::redirect::Policy::none())
+    .build()
+    .unwrap();
+
+  OidcTestContext {
+    _mock_idp: mock_idp,
+    _backend: backend,
+    _ferron: ferron,
+    base_url: format!("http://127.0.0.1:{}", ferron_port),
+    idp_base_url: format!("http://127.0.0.1:{}", idp_port),
+    client,
+    _config_file: config_file,
+  }
+}
+
+/// Extracts a cookie value from the `Set-Cookie` response headers
+fn get_set_cookie(response: &reqwest::Response, cookie_name: &str) -> Option<String> {
+  response
+    .headers()
+    .get_all(reqwest::header::SET_COOKIE)
+    .iter()
+    .filter_map(|v| v.to_str().ok())
+    .find_map(|v| {
+      let (name_value, _) = v.split_once(';')?;
+      let (name, value) = name_value.split_once('=')?;
+      (name == cookie_name).then(|| value.to_string())
+    })
+}
+
+#[tokio::test]
+async fn test_oidc_full_flow() {
+  let ctx = setup("full-flow").await;
+
+  // Step 1: an unauthenticated navigation request is redirected to the OIDC provider
+  let response = ctx.client.get(format!("{}/", ctx.base_url)).send().await.unwrap();
+  assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+  let authorization_url = response
+    .headers()
+    .get(reqwest::header::LOCATION)
+    .unwrap()
+    .to_str()
+    .unwrap()
+    .to_string();
+  assert!(
+    authorization_url.starts_with("http://mockidp:8080/default/authorize"),
+    "unexpected authorization URL: {authorization_url}"
+  );
+  let state_cookie = get_set_cookie(&response, "ferron_oidc_session_state").expect("state cookie not set");
+
+  // Step 2: the OIDC provider (reached through its host-mapped port) redirects back with a code
+  let authorization_url_from_host = authorization_url.replace("http://mockidp:8080", &ctx.idp_base_url);
+  let response = ctx.client.get(authorization_url_from_host).send().await.unwrap();
+  assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+  let callback_url = response
+    .headers()
+    .get(reqwest::header::LOCATION)
+    .unwrap()
+    .to_str()
+    .unwrap()
+    .to_string();
+  assert!(
+    callback_url.contains("/.ferron/oidc/callback"),
+    "unexpected callback URL: {callback_url}"
+  );
+  assert!(callback_url.contains("code="), "no authorization code: {callback_url}");
+
+  // Step 3: the callback exchanges the code and sets the session cookie
+  let response = ctx
+    .client
+    .get(&callback_url)
+    .header(
+      reqwest::header::COOKIE,
+      format!("ferron_oidc_session_state={state_cookie}"),
+    )
+    .send()
+    .await
+    .unwrap();
+  assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+  assert_eq!(
+    response.headers().get(reqwest::header::LOCATION).unwrap().to_str().unwrap(),
+    "/"
+  );
+  let session_cookie = get_set_cookie(&response, "ferron_oidc_session").expect("session cookie not set");
+  assert!(!session_cookie.is_empty());
+
+  // Step 4: the session cookie authenticates the request, and the backend
+  // receives the Remote-User header
+  let response = ctx
+    .client
+    .get(format!("{}/remote-user", ctx.base_url))
+    .header(reqwest::header::COOKIE, format!("ferron_oidc_session={session_cookie}"))
+    .send()
+    .await
+    .unwrap();
+  assert_eq!(response.status(), reqwest::StatusCode::OK);
+  let remote_user = response.text().await.unwrap();
+  assert!(!remote_user.is_empty(), "no Remote-User header received by the backend");
+
+  // Step 5: logging out expires the session cookie
+  let response = ctx
+    .client
+    .get(format!("{}/oidc-logout", ctx.base_url))
+    .header(reqwest::header::COOKIE, format!("ferron_oidc_session={session_cookie}"))
+    .send()
+    .await
+    .unwrap();
+  assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+  let expired_cookie = get_set_cookie(&response, "ferron_oidc_session").expect("session cookie not expired");
+  assert!(expired_cookie.is_empty());
+}
+
+#[tokio::test]
+async fn test_oidc_invalid_session_redirects_to_login() {
+  let ctx = setup("invalid-session").await;
+
+  let response = ctx
+    .client
+    .get(format!("{}/", ctx.base_url))
+    .header(reqwest::header::COOKIE, "ferron_oidc_session=garbage")
+    .send()
+    .await
+    .unwrap();
+  assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+  let location = response
+    .headers()
+    .get(reqwest::header::LOCATION)
+    .unwrap()
+    .to_str()
+    .unwrap();
+  assert!(location.starts_with("http://mockidp:8080/default/authorize"));
+}
+
+#[tokio::test]
+async fn test_oidc_api_request_unauthorized() {
+  let ctx = setup("api-request").await;
+
+  let response = ctx
+    .client
+    .get(format!("{}/", ctx.base_url))
+    .header("x-requested-with", "XMLHttpRequest")
+    .send()
+    .await
+    .unwrap();
+  assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_oidc_callback_without_state_rejected() {
+  let ctx = setup("callback-no-state").await;
+
+  let response = ctx
+    .client
+    .get(format!("{}/.ferron/oidc/callback?code=x&state=y", ctx.base_url))
+    .send()
+    .await
+    .unwrap();
+  assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+}

--- a/e2e/tests/oidc.rs
+++ b/e2e/tests/oidc.rs
@@ -50,9 +50,15 @@ async fn create_ferron_container(
   ferron_image
     .with_exposed_port(ContainerPort::Tcp(80))
     .with_wait_for(WaitFor::Http(Box::new(
+      // The header makes Ferron respond with 401 instead of redirecting to the OIDC
+      // provider, which the wait strategy's HTTP client would try to follow.
       HttpWaitStrategy::new("/")
         .with_port(ContainerPort::Tcp(80))
-        .with_response_matcher(|_| true),
+        .with_header(
+          "x-requested-with",
+          reqwest::header::HeaderValue::from_static("XMLHttpRequest"),
+        )
+        .with_response_matcher(|response| response.status() == reqwest::StatusCode::UNAUTHORIZED),
     )))
     .with_network(network)
     .with_hostname("ferron")
@@ -198,7 +204,12 @@ async fn test_oidc_full_flow() {
     .unwrap();
   assert_eq!(response.status(), reqwest::StatusCode::FOUND);
   assert_eq!(
-    response.headers().get(reqwest::header::LOCATION).unwrap().to_str().unwrap(),
+    response
+      .headers()
+      .get(reqwest::header::LOCATION)
+      .unwrap()
+      .to_str()
+      .unwrap(),
     "/"
   );
   let session_cookie = get_set_cookie(&response, "ferron_oidc_session").expect("session cookie not set");

--- a/ferron-build.yaml
+++ b/ferron-build.yaml
@@ -27,6 +27,9 @@ modules:
     cargo_feature: fauth
     loader: ForwardedAuthenticationModuleLoader
   - builtin: true
+    cargo_feature: oidc
+    loader: OidcModuleLoader
+  - builtin: true
     cargo_feature: cache
     loader: CacheModuleLoader
   - builtin: true

--- a/ferron-common/src/http_proxy/builder.rs
+++ b/ferron-common/src/http_proxy/builder.rs
@@ -269,9 +269,9 @@ impl<'a> ReverseProxyBuilder<'a> {
       proxy_http2: self.proxy_http2,
       proxy_keepalive: self.proxy_keepalive,
       proxy_header: self.proxy_proxy_header,
-      headers_to_add: Arc::new(self.proxy_request_header.drain(..).collect()),
-      headers_to_replace: Arc::new(self.proxy_request_header_replace.drain(..).collect()),
-      headers_to_remove: Arc::new(self.proxy_request_header_remove.drain(..).collect()),
+      headers_to_add: Arc::new(std::mem::take(&mut self.proxy_request_header)),
+      headers_to_replace: Arc::new(std::mem::take(&mut self.proxy_request_header_replace)),
+      headers_to_remove: Arc::new(std::mem::take(&mut self.proxy_request_header_remove)),
       rewrite_host: self.rewrite_host,
       connections,
       #[cfg(unix)]

--- a/ferron-load-modules/Cargo.toml
+++ b/ferron-load-modules/Cargo.toml
@@ -14,6 +14,7 @@ ferron-modules-builtin = { workspace = true, features = [
     "fproxy",
     "fproxyauth",
     "limit",
+    "oidc",
     "replace",
     "rproxy",
     "scgi",

--- a/ferron-modules-builtin/Cargo.toml
+++ b/ferron-modules-builtin/Cargo.toml
@@ -81,6 +81,17 @@ smallvec = { version = "1.15.0", features = [
     "const_generics",
 ] }
 
+# OpenID Connect authentication
+openidconnect = { version = "4.0.1", optional = true, default-features = false }
+reqwest = { version = "0.13.4", optional = true, default-features = false, features = [
+    "rustls",
+] }
+chacha20poly1305 = { version = "0.10.1", optional = true }
+hkdf = { version = "0.12.4", optional = true }
+sha2 = { version = "0.10.9", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
+
 # Gateway interfaces
 cegla = { version = "0.2.0", optional = true, default-features = false, features = ["client"] }
 cegla-cgi = { version = "0.2.0", optional = true, default-features = false, features = ["client"] }
@@ -101,6 +112,7 @@ default = [
     "fproxy",
     "fproxyauth",
     "limit",
+    "oidc",
     "replace",
     "rproxy",
     "runtime-monoio",
@@ -116,6 +128,7 @@ default-tokio = [
     "fproxy",
     "fproxyauth",
     "limit",
+    "oidc",
     "replace",
     "rproxy",
     "runtime-tokio",
@@ -131,6 +144,7 @@ default-vibeio = [
     "fproxy",
     "fproxyauth",
     "limit",
+    "oidc",
     "replace",
     "rproxy",
     "runtime-vibeio",
@@ -145,6 +159,7 @@ fcgi = ["tokio-util/codec", "cegla"]
 fproxy = []
 fproxyauth = []
 limit = ["tokenbucket"]
+oidc = ["openidconnect", "reqwest", "chacha20poly1305", "hkdf", "sha2", "serde", "serde_json"]
 replace = ["memchr"]
 rproxy = ["ferron-common/http-proxy"]
 runtime-vibeio = ["vibeio", "vibeio-hyper", "send_wrapper", "ferron-common/runtime-vibeio", "vibeio-http"]

--- a/ferron-modules-builtin/src/optional/mod.rs
+++ b/ferron-modules-builtin/src/optional/mod.rs
@@ -14,6 +14,8 @@ mod fproxy;
 mod fproxyauth;
 #[cfg(feature = "limit")]
 mod limit;
+#[cfg(feature = "oidc")]
+mod oidc;
 #[cfg(feature = "replace")]
 mod replace;
 #[cfg(feature = "rproxy")]
@@ -39,6 +41,8 @@ pub use fproxy::*;
 pub use fproxyauth::*;
 #[cfg(feature = "limit")]
 pub use limit::*;
+#[cfg(feature = "oidc")]
+pub use oidc::*;
 #[cfg(feature = "static")]
 pub use r#static::*;
 #[cfg(feature = "replace")]

--- a/ferron-modules-builtin/src/optional/oidc.rs
+++ b/ferron-modules-builtin/src/optional/oidc.rs
@@ -1,0 +1,754 @@
+use std::error::Error;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use base64::prelude::*;
+use bytes::Bytes;
+use chacha20poly1305::aead::{KeyInit, OsRng};
+use chacha20poly1305::XChaCha20Poly1305;
+use ferron_common::logging::ErrorLogger;
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt, Empty};
+use hyper::header::{HeaderName, HeaderValue};
+use hyper::{header, Request, Response, StatusCode};
+
+use ferron_common::modules::{Module, ModuleHandlers, ModuleLoader, RequestData, ResponseData, SocketData};
+use ferron_common::{config::ServerConfiguration, util::ModuleCache};
+use ferron_common::{get_entries_for_validation, get_value, get_values};
+
+use crate::util::oidc::cookie::{
+  expire_cookie_header, get_cookie, sanitize_redirect_target, set_cookie_header, CookieKeys, SessionPayload,
+  StatePayload,
+};
+use crate::util::oidc::flow::{begin_login, exchange_code, OidcFlowConfig, SessionClaims};
+use crate::util::oidc::http_client::build_http_client;
+use crate::util::oidc::provider::ProviderCache;
+
+/// The default OIDC session time-to-live (in seconds)
+const DEFAULT_SESSION_TTL: u64 = 86400;
+
+/// The time-to-live of the OIDC state cookie (in seconds)
+const STATE_TTL: u64 = 600;
+
+/// The default OIDC session cookie name
+const DEFAULT_COOKIE_NAME: &str = "ferron_oidc_session";
+
+/// The default OIDC redirect (callback) path
+const DEFAULT_REDIRECT_PATH: &str = "/.ferron/oidc/callback";
+
+/// Identity request headers, stripped from incoming requests and injected for
+/// authenticated users (compatible with the headers used by Authelia)
+const IDENTITY_HEADERS: [HeaderName; 4] = [
+  HeaderName::from_static("remote-user"),
+  HeaderName::from_static("remote-groups"),
+  HeaderName::from_static("remote-email"),
+  HeaderName::from_static("remote-name"),
+];
+
+/// An OIDC authentication module loader
+pub struct OidcModuleLoader {
+  cache: ModuleCache<OidcModule>,
+}
+
+impl Default for OidcModuleLoader {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl OidcModuleLoader {
+  /// Creates a new module loader
+  pub fn new() -> Self {
+    Self {
+      cache: ModuleCache::new(vec![
+        "auth_oidc",
+        "auth_oidc_client_id",
+        "auth_oidc_client_secret",
+        "auth_oidc_scopes",
+        "auth_oidc_cookie_secret",
+        "auth_oidc_cookie_name",
+        "auth_oidc_session_ttl",
+        "auth_oidc_redirect_path",
+        "auth_oidc_logout_path",
+        "auth_oidc_post_logout_redirect",
+        "auth_oidc_headers",
+        "auth_oidc_user_claim",
+        "auth_oidc_allowed_groups",
+        "auth_oidc_audience",
+        "auth_oidc_no_verification",
+      ]),
+    }
+  }
+}
+
+impl ModuleLoader for OidcModuleLoader {
+  fn load_module(
+    &mut self,
+    config: &ServerConfiguration,
+    _global_config: Option<&ServerConfiguration>,
+    secondary_runtime: &tokio::runtime::Runtime,
+  ) -> Result<Arc<dyn Module + Send + Sync>, Box<dyn Error + Send + Sync>> {
+    let runtime_handle = secondary_runtime.handle().to_owned();
+    Ok(
+      self
+        .cache
+        .get_or_init::<_, Box<dyn std::error::Error + Send + Sync>>(config, move |config| {
+          let issuer_url = get_value!("auth_oidc", config)
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("The OIDC issuer URL is not specified"))?
+            .to_string();
+          let client_id = get_value!("auth_oidc_client_id", config)
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("The OIDC client ID is not specified"))?
+            .to_string();
+          let client_secret = get_value!("auth_oidc_client_secret", config)
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+          let scopes = {
+            let scopes = get_values!("auth_oidc_scopes", config)
+              .into_iter()
+              .filter_map(|v| v.as_str().map(|s| s.to_string()))
+              .collect::<Vec<_>>();
+            if scopes.is_empty() {
+              vec!["openid".to_string(), "profile".to_string(), "email".to_string()]
+            } else {
+              scopes
+            }
+          };
+          let cookie_keys = match get_value!("auth_oidc_cookie_secret", config).and_then(|v| v.as_str()) {
+            Some(secret) => {
+              let secret = BASE64_STANDARD
+                .decode(secret)
+                .map_err(|_| anyhow::anyhow!("The OIDC cookie secret is not valid Base64"))?;
+              if secret.len() < 32 {
+                Err(anyhow::anyhow!(
+                  "The OIDC cookie secret must be at least 32 bytes long after decoding"
+                ))?;
+              }
+              CookieKeys::derive(&secret)
+            }
+            None => {
+              // Without a configured cookie secret, sessions don't survive server restarts
+              // and can't be shared between multiple server instances.
+              CookieKeys::derive(&XChaCha20Poly1305::generate_key(&mut OsRng))
+            }
+          };
+          let cookie_name = get_value!("auth_oidc_cookie_name", config)
+            .and_then(|v| v.as_str())
+            .unwrap_or(DEFAULT_COOKIE_NAME)
+            .to_string();
+          let session_ttl = get_value!("auth_oidc_session_ttl", config)
+            .and_then(|v| v.as_i128())
+            .map(|v| v as u64)
+            .unwrap_or(DEFAULT_SESSION_TTL);
+          let redirect_path = get_value!("auth_oidc_redirect_path", config)
+            .and_then(|v| v.as_str())
+            .unwrap_or(DEFAULT_REDIRECT_PATH)
+            .to_string();
+          let logout_path = get_value!("auth_oidc_logout_path", config)
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+          let post_logout_redirect = get_value!("auth_oidc_post_logout_redirect", config)
+            .and_then(|v| v.as_str())
+            .unwrap_or("/")
+            .to_string();
+          let inject_headers = get_value!("auth_oidc_headers", config)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+          let user_claim = get_value!("auth_oidc_user_claim", config)
+            .and_then(|v| v.as_str())
+            .unwrap_or("preferred_username")
+            .to_string();
+          let allowed_groups = get_values!("auth_oidc_allowed_groups", config)
+            .into_iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect::<Vec<_>>();
+          let audiences = get_values!("auth_oidc_audience", config)
+            .into_iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect::<Vec<_>>();
+          let no_verification = get_value!("auth_oidc_no_verification", config)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+          let http_client = build_http_client(no_verification)?;
+
+          Ok(Arc::new(OidcModule {
+            inner: Arc::new(OidcModuleInner {
+              issuer_url,
+              client_id,
+              client_secret,
+              scopes,
+              cookie_keys,
+              cookie_name,
+              session_ttl,
+              redirect_path,
+              logout_path,
+              post_logout_redirect,
+              inject_headers,
+              user_claim,
+              allowed_groups,
+              audiences,
+              http_client,
+              provider_cache: ProviderCache::new(),
+              runtime_handle,
+            }),
+          }))
+        })?,
+    )
+  }
+
+  fn get_requirements(&self) -> Vec<&'static str> {
+    vec!["auth_oidc"]
+  }
+
+  fn validate_configuration(
+    &self,
+    config: &ServerConfiguration,
+    used_properties: &mut std::collections::HashSet<String>,
+  ) -> Result<(), Box<dyn Error + Send + Sync>> {
+    macro_rules! validate_single_string {
+      ($name:literal, $description:literal) => {
+        if let Some(entries) = get_entries_for_validation!($name, config, used_properties) {
+          for entry in &entries.inner {
+            if entry.values.len() != 1 {
+              Err(anyhow::anyhow!(concat!(
+                "The `",
+                $name,
+                "` configuration property must have exactly one value"
+              )))?
+            } else if !entry.values[0].is_string() {
+              Err(anyhow::anyhow!(concat!("Invalid ", $description)))?
+            }
+          }
+        }
+      };
+    }
+    validate_single_string!("auth_oidc", "OIDC issuer URL");
+    validate_single_string!("auth_oidc_client_id", "OIDC client ID");
+    validate_single_string!("auth_oidc_client_secret", "OIDC client secret");
+    validate_single_string!("auth_oidc_cookie_secret", "OIDC cookie secret");
+    validate_single_string!("auth_oidc_cookie_name", "OIDC cookie name");
+    validate_single_string!("auth_oidc_user_claim", "OIDC user claim");
+    validate_single_string!("auth_oidc_post_logout_redirect", "OIDC post-logout redirect target");
+
+    macro_rules! validate_path {
+      ($name:literal, $description:literal, $nullable:literal) => {
+        if let Some(entries) = get_entries_for_validation!($name, config, used_properties) {
+          for entry in &entries.inner {
+            if entry.values.len() != 1 {
+              Err(anyhow::anyhow!(concat!(
+                "The `",
+                $name,
+                "` configuration property must have exactly one value"
+              )))?
+            } else if $nullable && entry.values[0].is_null() {
+              continue;
+            } else if !entry.values[0].as_str().is_some_and(|v| v.starts_with('/')) {
+              Err(anyhow::anyhow!(concat!(
+                "Invalid ",
+                $description,
+                "; it must begin with \"/\""
+              )))?
+            }
+          }
+        }
+      };
+    }
+    validate_path!("auth_oidc_redirect_path", "OIDC redirect path", false);
+    validate_path!("auth_oidc_logout_path", "OIDC logout path", true);
+
+    macro_rules! validate_boolean {
+      ($name:literal, $description:literal) => {
+        if let Some(entries) = get_entries_for_validation!($name, config, used_properties) {
+          for entry in &entries.inner {
+            if entry.values.len() != 1 {
+              Err(anyhow::anyhow!(concat!(
+                "The `",
+                $name,
+                "` configuration property must have exactly one value"
+              )))?
+            } else if !entry.values[0].is_bool() {
+              Err(anyhow::anyhow!(concat!("Invalid ", $description)))?
+            }
+          }
+        }
+      };
+    }
+    validate_boolean!("auth_oidc_headers", "OIDC identity header injection option");
+    validate_boolean!(
+      "auth_oidc_no_verification",
+      "OIDC provider certificate verification option"
+    );
+
+    macro_rules! validate_string_list {
+      ($name:literal, $description:literal) => {
+        if let Some(entries) = get_entries_for_validation!($name, config, used_properties) {
+          for entry in &entries.inner {
+            for value in &entry.values {
+              if !value.is_string() {
+                Err(anyhow::anyhow!(concat!("Invalid ", $description)))?
+              }
+            }
+          }
+        }
+      };
+    }
+    validate_string_list!("auth_oidc_scopes", "OIDC scopes");
+    validate_string_list!("auth_oidc_allowed_groups", "OIDC allowed groups");
+    validate_string_list!("auth_oidc_audience", "OIDC audiences");
+
+    if let Some(entries) = get_entries_for_validation!("auth_oidc_session_ttl", config, used_properties) {
+      for entry in &entries.inner {
+        if entry.values.len() != 1 {
+          Err(anyhow::anyhow!(
+            "The `auth_oidc_session_ttl` configuration property must have exactly one value"
+          ))?
+        } else if !entry.values[0].is_integer() || entry.values[0].as_i128().is_some_and(|v| v < 1) {
+          Err(anyhow::anyhow!("Invalid OIDC session time-to-live"))?
+        }
+      }
+    }
+
+    Ok(())
+  }
+}
+
+/// The OIDC authentication module configuration and shared state
+struct OidcModuleInner {
+  issuer_url: String,
+  client_id: String,
+  client_secret: Option<String>,
+  scopes: Vec<String>,
+  cookie_keys: CookieKeys,
+  cookie_name: String,
+  session_ttl: u64,
+  redirect_path: String,
+  logout_path: Option<String>,
+  post_logout_redirect: String,
+  inject_headers: bool,
+  user_claim: String,
+  allowed_groups: Vec<String>,
+  audiences: Vec<String>,
+  http_client: reqwest::Client,
+  provider_cache: ProviderCache,
+  runtime_handle: tokio::runtime::Handle,
+}
+
+impl OidcModuleInner {
+  /// The name of the OIDC state cookie
+  fn state_cookie_name(&self) -> String {
+    format!("{}_state", self.cookie_name)
+  }
+
+  /// Constructs the OIDC flow configuration for the specified redirect URL
+  fn flow_config(&self, redirect_url: String) -> OidcFlowConfig {
+    OidcFlowConfig {
+      client_id: self.client_id.clone(),
+      client_secret: self.client_secret.clone(),
+      scopes: self.scopes.clone(),
+      redirect_url,
+      audiences: self.audiences.clone(),
+    }
+  }
+
+  /// Determines the authenticated username from the identity claims
+  fn pick_user(&self, username: Option<&str>, email: Option<&str>, sub: &str) -> String {
+    match &self.user_claim as &str {
+      "email" => email.or(username),
+      "sub" => None,
+      _ => username.or(email),
+    }
+    .unwrap_or(sub)
+    .to_string()
+  }
+}
+
+/// An OIDC authentication module
+struct OidcModule {
+  inner: Arc<OidcModuleInner>,
+}
+
+impl Module for OidcModule {
+  fn get_module_handlers(&self) -> Box<dyn ModuleHandlers> {
+    Box::new(OidcModuleHandlers {
+      inner: self.inner.clone(),
+    })
+  }
+}
+
+/// OIDC authentication module handlers
+struct OidcModuleHandlers {
+  inner: Arc<OidcModuleInner>,
+}
+
+#[async_trait(?Send)]
+impl ModuleHandlers for OidcModuleHandlers {
+  async fn request_handler(
+    &mut self,
+    mut request: Request<BoxBody<Bytes, std::io::Error>>,
+    _config: &ServerConfiguration,
+    socket_data: &SocketData,
+    error_logger: &ErrorLogger,
+  ) -> Result<ResponseData, Box<dyn Error + Send + Sync>> {
+    let inner = &self.inner;
+    let secure = socket_data.encrypted;
+
+    // Always strip client-supplied identity headers
+    for identity_header in IDENTITY_HEADERS.iter() {
+      while request.headers_mut().remove(identity_header).is_some() {}
+    }
+
+    let request_path = request.uri().path().to_string();
+
+    // Local logout: expire the session cookie and redirect
+    if inner.logout_path.as_deref() == Some(&request_path) {
+      return Ok(short_circuit(redirect_response(
+        sanitize_redirect_target(&inner.post_logout_redirect),
+        vec![expire_cookie_header(&inner.cookie_name, secure)],
+      )?));
+    }
+
+    // OIDC callback: exchange the authorization code for a verified session
+    if request_path == inner.redirect_path {
+      return self.handle_callback(request, secure, error_logger).await;
+    }
+
+    // Check for an existing session
+    let session_cookie = get_cookie(
+      request.headers().get_all(header::COOKIE).iter().map(|v| v.as_bytes()),
+      &inner.cookie_name,
+    );
+    if let Some(session_cookie) = session_cookie {
+      if let Ok(session) = inner.cookie_keys.unseal_session(&session_cookie) {
+        if session.exp > unix_timestamp() {
+          return self.handle_authenticated(request, session);
+        }
+      }
+    }
+
+    // Unauthenticated: redirect navigation requests to the OIDC provider, and
+    // respond with 401 Unauthorized to API-style requests
+    let is_navigation = (request.method() == hyper::Method::GET || request.method() == hyper::Method::HEAD)
+      && request
+        .headers()
+        .get("sec-fetch-mode")
+        .is_none_or(|v| v.as_bytes() != b"cors")
+      && !request.headers().contains_key("x-requested-with");
+    if !is_navigation {
+      return Ok(status_response(StatusCode::UNAUTHORIZED, None));
+    }
+
+    self.handle_login_redirect(request, secure, error_logger).await
+  }
+}
+
+impl OidcModuleHandlers {
+  /// Redirects an unauthenticated request to the OIDC provider's authorization endpoint
+  async fn handle_login_redirect(
+    &self,
+    request: Request<BoxBody<Bytes, std::io::Error>>,
+    secure: bool,
+    error_logger: &ErrorLogger,
+  ) -> Result<ResponseData, Box<dyn Error + Send + Sync>> {
+    let inner = self.inner.clone();
+    let redirect_url = match construct_redirect_url(&request, secure, &inner.redirect_path) {
+      Some(redirect_url) => redirect_url,
+      None => return Ok(status_response(StatusCode::BAD_REQUEST, None)),
+    };
+    let original_url = format!(
+      "{}{}",
+      request.uri().path(),
+      match request.uri().query() {
+        Some(query) => format!("?{query}"),
+        None => String::new(),
+      }
+    );
+
+    let inner_spawned = inner.clone();
+    let begin = inner
+      .runtime_handle
+      .spawn(async move {
+        let metadata = inner_spawned
+          .provider_cache
+          .get_metadata(&inner_spawned.http_client, &inner_spawned.issuer_url)
+          .await?;
+        begin_login(metadata, &inner_spawned.flow_config(redirect_url))
+      })
+      .await?;
+    let begin = match begin {
+      Ok(begin) => begin,
+      Err(e) => {
+        error_logger.log(&format!("OIDC login initiation failed: {e}")).await;
+        return Ok(status_response(StatusCode::SERVICE_UNAVAILABLE, None));
+      }
+    };
+
+    let state_payload = StatePayload {
+      state: begin.state,
+      pkce_verifier: begin.pkce_verifier,
+      nonce: begin.nonce,
+      original_url,
+      iat: unix_timestamp(),
+    };
+    let state_cookie = inner.cookie_keys.seal_state(&state_payload)?;
+
+    Ok(short_circuit(redirect_response(
+      &begin.authorization_url,
+      vec![set_cookie_header(
+        &inner.state_cookie_name(),
+        &state_cookie,
+        STATE_TTL,
+        secure,
+      )],
+    )?))
+  }
+
+  /// Handles the OIDC callback request
+  async fn handle_callback(
+    &self,
+    request: Request<BoxBody<Bytes, std::io::Error>>,
+    secure: bool,
+    error_logger: &ErrorLogger,
+  ) -> Result<ResponseData, Box<dyn Error + Send + Sync>> {
+    let inner = self.inner.clone();
+    let expire_state = vec![expire_cookie_header(&inner.state_cookie_name(), secure)];
+
+    let query_params = parse_query(request.uri().query().unwrap_or(""));
+    let state_param = query_params.iter().find(|(k, _)| k == "state").map(|(_, v)| v.clone());
+    let code_param = query_params.iter().find(|(k, _)| k == "code").map(|(_, v)| v.clone());
+    let error_param = query_params.iter().find(|(k, _)| k == "error").map(|(_, v)| v.clone());
+
+    if let Some(error_param) = error_param {
+      error_logger
+        .log(&format!("The OIDC provider returned an error: {error_param}"))
+        .await;
+      return Ok(status_response(StatusCode::FORBIDDEN, Some(expire_state)));
+    }
+
+    let state_cookie = get_cookie(
+      request.headers().get_all(header::COOKIE).iter().map(|v| v.as_bytes()),
+      &inner.state_cookie_name(),
+    );
+    let state_payload = match state_cookie.and_then(|c| inner.cookie_keys.unseal_state(&c).ok()) {
+      Some(state_payload) => state_payload,
+      None => {
+        error_logger
+          .log("OIDC callback request without a valid state cookie")
+          .await;
+        return Ok(status_response(StatusCode::BAD_REQUEST, Some(expire_state)));
+      }
+    };
+    if state_payload.iat + STATE_TTL < unix_timestamp() || state_param.as_deref() != Some(&state_payload.state as &str)
+    {
+      error_logger
+        .log("OIDC callback request with an expired or mismatched state")
+        .await;
+      return Ok(status_response(StatusCode::BAD_REQUEST, Some(expire_state)));
+    }
+    let code = match code_param {
+      Some(code) => code,
+      None => {
+        return Ok(status_response(StatusCode::BAD_REQUEST, Some(expire_state)));
+      }
+    };
+
+    let redirect_url = match construct_redirect_url(&request, secure, &inner.redirect_path) {
+      Some(redirect_url) => redirect_url,
+      None => return Ok(status_response(StatusCode::BAD_REQUEST, Some(expire_state))),
+    };
+
+    let inner_spawned = inner.clone();
+    let pkce_verifier = state_payload.pkce_verifier.clone();
+    let nonce = state_payload.nonce.clone();
+    let claims = inner
+      .runtime_handle
+      .spawn(async move {
+        let metadata = inner_spawned
+          .provider_cache
+          .get_metadata(&inner_spawned.http_client, &inner_spawned.issuer_url)
+          .await?;
+        let flow_config = inner_spawned.flow_config(redirect_url);
+        let result = exchange_code(
+          metadata,
+          &flow_config,
+          &inner_spawned.http_client,
+          code,
+          pkce_verifier,
+          nonce,
+        )
+        .await;
+        if result.is_err() {
+          // The failure might be caused by rotated OIDC provider signing keys;
+          // refresh the cached metadata, so that the next login attempt succeeds.
+          let _ = inner_spawned
+            .provider_cache
+            .refresh_metadata(&inner_spawned.http_client, &inner_spawned.issuer_url)
+            .await;
+        }
+        result
+      })
+      .await?;
+    let claims: SessionClaims = match claims {
+      Ok(claims) => claims,
+      Err(e) => {
+        error_logger.log(&format!("OIDC authentication failed: {e}")).await;
+        return Ok(status_response(StatusCode::UNAUTHORIZED, Some(expire_state)));
+      }
+    };
+
+    let now = unix_timestamp();
+    let session_payload = SessionPayload {
+      sub: claims.sub,
+      username: claims.username,
+      email: claims.email,
+      name: claims.name,
+      groups: claims.groups,
+      iat: now,
+      exp: now + inner.session_ttl,
+    };
+    let session_cookie = inner.cookie_keys.seal_session(&session_payload)?;
+
+    Ok(short_circuit(redirect_response(
+      sanitize_redirect_target(&state_payload.original_url),
+      vec![
+        set_cookie_header(&inner.cookie_name, &session_cookie, inner.session_ttl, secure),
+        expire_cookie_header(&inner.state_cookie_name(), secure),
+      ],
+    )?))
+  }
+
+  /// Handles a request with a valid session
+  fn handle_authenticated(
+    &self,
+    mut request: Request<BoxBody<Bytes, std::io::Error>>,
+    session: SessionPayload,
+  ) -> Result<ResponseData, Box<dyn Error + Send + Sync>> {
+    let inner = &self.inner;
+
+    if !inner.allowed_groups.is_empty() && !session.groups.iter().any(|group| inner.allowed_groups.contains(group)) {
+      return Ok(status_response(StatusCode::FORBIDDEN, None));
+    }
+
+    let auth_user = inner.pick_user(session.username.as_deref(), session.email.as_deref(), &session.sub);
+    if let Some(request_data) = request.extensions_mut().get_mut::<RequestData>() {
+      request_data.auth_user = Some(auth_user.clone());
+    }
+
+    if inner.inject_headers {
+      let headers = request.headers_mut();
+      headers.insert(&IDENTITY_HEADERS[0], HeaderValue::from_str(&auth_user)?);
+      if !session.groups.is_empty() {
+        headers.insert(&IDENTITY_HEADERS[1], HeaderValue::from_str(&session.groups.join(","))?);
+      }
+      if let Some(email) = &session.email {
+        if let Ok(header_value) = HeaderValue::from_str(email) {
+          headers.insert(&IDENTITY_HEADERS[2], header_value);
+        }
+      }
+      if let Some(name) = &session.name {
+        if let Ok(header_value) = HeaderValue::from_str(name) {
+          headers.insert(&IDENTITY_HEADERS[3], header_value);
+        }
+      }
+    }
+
+    Ok(ResponseData {
+      request: Some(request),
+      response: None,
+      response_status: None,
+      response_headers: None,
+      new_remote_address: None,
+    })
+  }
+}
+
+/// The current Unix timestamp (in seconds)
+fn unix_timestamp() -> u64 {
+  SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .map(|d| d.as_secs())
+    .unwrap_or(0)
+}
+
+/// Constructs the OIDC redirect URL from the request's host and the configured redirect path
+fn construct_redirect_url(
+  request: &Request<BoxBody<Bytes, std::io::Error>>,
+  secure: bool,
+  redirect_path: &str,
+) -> Option<String> {
+  let host = request
+    .uri()
+    .authority()
+    .map(|authority| authority.to_string())
+    .or_else(|| {
+      request
+        .headers()
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.to_string())
+    })?;
+  let scheme = if secure { "https" } else { "http" };
+  Some(format!("{scheme}://{host}{redirect_path}"))
+}
+
+/// Parses a query string into key-value pairs
+fn parse_query(query: &str) -> Vec<(String, String)> {
+  query
+    .split('&')
+    .filter_map(|pair| {
+      let (key, value) = pair.split_once('=')?;
+      Some((
+        urlencoding::decode(key).ok()?.into_owned(),
+        urlencoding::decode(value).ok()?.into_owned(),
+      ))
+    })
+    .collect()
+}
+
+/// Constructs a redirect response with the specified cookies
+fn redirect_response(
+  location: &str,
+  set_cookies: Vec<String>,
+) -> Result<Response<BoxBody<Bytes, std::io::Error>>, Box<dyn Error + Send + Sync>> {
+  let mut builder = Response::builder()
+    .status(StatusCode::FOUND)
+    .header(header::LOCATION, location);
+  for set_cookie in set_cookies {
+    builder = builder.header(header::SET_COOKIE, set_cookie);
+  }
+  Ok(builder.body(Empty::new().map_err(|e| match e {}).boxed())?)
+}
+
+/// Constructs a response data structure short-circuiting with the specified response
+fn short_circuit(response: Response<BoxBody<Bytes, std::io::Error>>) -> ResponseData {
+  ResponseData {
+    request: None,
+    response: Some(response),
+    response_status: None,
+    response_headers: None,
+    new_remote_address: None,
+  }
+}
+
+/// Constructs a response data structure with a status code and optional cookies,
+/// letting the error page handlers render the response body
+fn status_response(status: StatusCode, set_cookies: Option<Vec<String>>) -> ResponseData {
+  let response_headers = set_cookies.map(|set_cookies| {
+    let mut headers = hyper::HeaderMap::new();
+    for set_cookie in set_cookies {
+      if let Ok(header_value) = HeaderValue::from_str(&set_cookie) {
+        headers.append(header::SET_COOKIE, header_value);
+      }
+    }
+    headers
+  });
+  ResponseData {
+    request: None,
+    response: None,
+    response_status: Some(status),
+    response_headers,
+    new_remote_address: None,
+  }
+}

--- a/ferron-modules-builtin/src/util/mod.rs
+++ b/ferron-modules-builtin/src/util/mod.rs
@@ -5,6 +5,8 @@ mod body_replacer;
 pub mod cache_control;
 #[cfg(feature = "fcgi")]
 pub mod fcgi;
+#[cfg(feature = "oidc")]
+pub mod oidc;
 #[cfg(any(feature = "dcompress", feature = "fcgi"))]
 mod split_stream_by_map;
 

--- a/ferron-modules-builtin/src/util/oidc/cookie.rs
+++ b/ferron-modules-builtin/src/util/oidc/cookie.rs
@@ -1,0 +1,250 @@
+use std::error::Error;
+
+use base64::prelude::*;
+use chacha20poly1305::aead::{Aead, AeadCore, KeyInit, OsRng};
+use chacha20poly1305::{XChaCha20Poly1305, XNonce};
+use hkdf::Hkdf;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use sha2::Sha256;
+
+/// The sealed OIDC session cookie payload
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct SessionPayload {
+  /// The OIDC subject identifier
+  pub sub: String,
+  /// The preferred username
+  pub username: Option<String>,
+  /// The email address
+  pub email: Option<String>,
+  /// The display name
+  pub name: Option<String>,
+  /// The groups the user belongs to
+  pub groups: Vec<String>,
+  /// The Unix timestamp at which the session was created
+  pub iat: u64,
+  /// The Unix timestamp at which the session expires
+  pub exp: u64,
+}
+
+/// The sealed OIDC state cookie payload, used during the authorization code flow
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct StatePayload {
+  /// The OAuth2 state parameter
+  pub state: String,
+  /// The PKCE code verifier
+  pub pkce_verifier: String,
+  /// The OpenID Connect nonce
+  pub nonce: String,
+  /// The URL (path and query string) to redirect to after a successful login
+  pub original_url: String,
+  /// The Unix timestamp at which the state was created
+  pub iat: u64,
+}
+
+/// Keys used to seal and unseal OIDC cookies, derived from the configured cookie secret
+pub struct CookieKeys {
+  session_key: [u8; 32],
+  state_key: [u8; 32],
+}
+
+impl CookieKeys {
+  /// Derives the cookie keys from a secret using HKDF-SHA256
+  pub fn derive(secret: &[u8]) -> Self {
+    let hkdf = Hkdf::<Sha256>::new(None, secret);
+    let mut session_key = [0u8; 32];
+    let mut state_key = [0u8; 32];
+    // 32-byte outputs never exceed the HKDF-SHA256 output limit
+    hkdf.expand(b"ferron-oidc-session", &mut session_key).unwrap();
+    hkdf.expand(b"ferron-oidc-state", &mut state_key).unwrap();
+    Self { session_key, state_key }
+  }
+
+  /// Seals the session cookie payload
+  pub fn seal_session(&self, payload: &SessionPayload) -> Result<String, Box<dyn Error + Send + Sync>> {
+    seal(&self.session_key, payload)
+  }
+
+  /// Unseals the session cookie payload
+  pub fn unseal_session(&self, sealed: &str) -> Result<SessionPayload, Box<dyn Error + Send + Sync>> {
+    unseal(&self.session_key, sealed)
+  }
+
+  /// Seals the state cookie payload
+  pub fn seal_state(&self, payload: &StatePayload) -> Result<String, Box<dyn Error + Send + Sync>> {
+    seal(&self.state_key, payload)
+  }
+
+  /// Unseals the state cookie payload
+  pub fn unseal_state(&self, sealed: &str) -> Result<StatePayload, Box<dyn Error + Send + Sync>> {
+    unseal(&self.state_key, sealed)
+  }
+}
+
+/// Seals a payload into a URL-safe Base64 string (random 24-byte nonce followed by the ciphertext)
+fn seal<T: Serialize>(key: &[u8; 32], payload: &T) -> Result<String, Box<dyn Error + Send + Sync>> {
+  let cipher = XChaCha20Poly1305::new(key.into());
+  let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+  let plaintext = serde_json::to_vec(payload)?;
+  let ciphertext = cipher
+    .encrypt(&nonce, plaintext.as_slice())
+    .map_err(|_| anyhow::anyhow!("Failed to encrypt the cookie payload"))?;
+  let mut sealed = Vec::with_capacity(nonce.len() + ciphertext.len());
+  sealed.extend_from_slice(&nonce);
+  sealed.extend_from_slice(&ciphertext);
+  Ok(BASE64_URL_SAFE_NO_PAD.encode(sealed))
+}
+
+/// Unseals a payload sealed with the `seal` function
+fn unseal<T: DeserializeOwned>(key: &[u8; 32], sealed: &str) -> Result<T, Box<dyn Error + Send + Sync>> {
+  let sealed = BASE64_URL_SAFE_NO_PAD
+    .decode(sealed)
+    .map_err(|_| anyhow::anyhow!("Invalid cookie encoding"))?;
+  if sealed.len() < 24 {
+    Err(anyhow::anyhow!("Invalid cookie length"))?;
+  }
+  let (nonce, ciphertext) = sealed.split_at(24);
+  let cipher = XChaCha20Poly1305::new(key.into());
+  let plaintext = cipher
+    .decrypt(XNonce::from_slice(nonce), ciphertext)
+    .map_err(|_| anyhow::anyhow!("Failed to decrypt the cookie payload"))?;
+  Ok(serde_json::from_slice(&plaintext)?)
+}
+
+/// Extracts a cookie value from `Cookie` request header values
+pub fn get_cookie<'a>(cookie_headers: impl Iterator<Item = &'a [u8]>, cookie_name: &str) -> Option<String> {
+  for header_value in cookie_headers {
+    let header_value = std::str::from_utf8(header_value).ok()?;
+    for cookie in header_value.split(';') {
+      let cookie = cookie.trim();
+      if let Some((name, value)) = cookie.split_once('=') {
+        if name == cookie_name {
+          return Some(value.to_string());
+        }
+      }
+    }
+  }
+  None
+}
+
+/// Builds a `Set-Cookie` header value setting a cookie
+pub fn set_cookie_header(cookie_name: &str, value: &str, max_age: u64, secure: bool) -> String {
+  format!(
+    "{cookie_name}={value}; Max-Age={max_age}; Path=/; HttpOnly; SameSite=Lax{}",
+    if secure { "; Secure" } else { "" }
+  )
+}
+
+/// Builds a `Set-Cookie` header value expiring a cookie
+pub fn expire_cookie_header(cookie_name: &str, secure: bool) -> String {
+  format!(
+    "{cookie_name}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax{}",
+    if secure { "; Secure" } else { "" }
+  )
+}
+
+/// Sanitizes a post-login or post-logout redirect target, allowing only local absolute paths
+pub fn sanitize_redirect_target(target: &str) -> &str {
+  if target.starts_with('/') && !target.starts_with("//") && !target.starts_with("/\\") {
+    target
+  } else {
+    "/"
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn keys() -> CookieKeys {
+    CookieKeys::derive(b"a test secret that is long enough")
+  }
+
+  fn session_payload() -> SessionPayload {
+    SessionPayload {
+      sub: "user-1".to_string(),
+      username: Some("someone".to_string()),
+      email: Some("someone@example.com".to_string()),
+      name: None,
+      groups: vec!["admins".to_string()],
+      iat: 1000,
+      exp: 2000,
+    }
+  }
+
+  #[test]
+  fn test_session_roundtrip() {
+    let keys = keys();
+    let payload = session_payload();
+    let sealed = keys.seal_session(&payload).unwrap();
+    assert_eq!(keys.unseal_session(&sealed).unwrap(), payload);
+  }
+
+  #[test]
+  fn test_state_roundtrip() {
+    let keys = keys();
+    let payload = StatePayload {
+      state: "state".to_string(),
+      pkce_verifier: "verifier".to_string(),
+      nonce: "nonce".to_string(),
+      original_url: "/protected?x=1".to_string(),
+      iat: 1000,
+    };
+    let sealed = keys.seal_state(&payload).unwrap();
+    assert_eq!(keys.unseal_state(&sealed).unwrap(), payload);
+  }
+
+  #[test]
+  fn test_tampered_cookie_rejected() {
+    let keys = keys();
+    let sealed = keys.seal_session(&session_payload()).unwrap();
+    let mut tampered = sealed.into_bytes();
+    let last = tampered.len() - 1;
+    tampered[last] = if tampered[last] == b'A' { b'B' } else { b'A' };
+    assert!(keys.unseal_session(&String::from_utf8(tampered).unwrap()).is_err());
+  }
+
+  #[test]
+  fn test_wrong_key_rejected() {
+    let sealed = keys().seal_session(&session_payload()).unwrap();
+    let other_keys = CookieKeys::derive(b"a different secret that is long enough");
+    assert!(other_keys.unseal_session(&sealed).is_err());
+  }
+
+  #[test]
+  fn test_session_cookie_not_valid_as_state_cookie() {
+    let keys = keys();
+    let sealed = keys.seal_session(&session_payload()).unwrap();
+    assert!(keys.unseal_state(&sealed).is_err());
+  }
+
+  #[test]
+  fn test_get_cookie() {
+    let headers: Vec<&[u8]> = vec![b"foo=bar; ferron_oidc_session=abc123; baz=qux"];
+    assert_eq!(
+      get_cookie(headers.clone().into_iter(), "ferron_oidc_session"),
+      Some("abc123".to_string())
+    );
+    assert_eq!(get_cookie(headers.into_iter(), "missing"), None);
+  }
+
+  #[test]
+  fn test_set_cookie_headers() {
+    assert_eq!(
+      set_cookie_header("c", "v", 3600, true),
+      "c=v; Max-Age=3600; Path=/; HttpOnly; SameSite=Lax; Secure"
+    );
+    assert_eq!(
+      expire_cookie_header("c", false),
+      "c=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax"
+    );
+  }
+
+  #[test]
+  fn test_sanitize_redirect_target() {
+    assert_eq!(sanitize_redirect_target("/some/path?a=b"), "/some/path?a=b");
+    assert_eq!(sanitize_redirect_target("//evil.example.com"), "/");
+    assert_eq!(sanitize_redirect_target("/\\evil.example.com"), "/");
+    assert_eq!(sanitize_redirect_target("https://evil.example.com"), "/");
+    assert_eq!(sanitize_redirect_target(""), "/");
+  }
+}

--- a/ferron-modules-builtin/src/util/oidc/flow.rs
+++ b/ferron-modules-builtin/src/util/oidc/flow.rs
@@ -1,0 +1,217 @@
+use std::error::Error;
+
+use base64::prelude::*;
+use openidconnect::core::{CoreAuthenticationFlow, CoreClient, CoreProviderMetadata};
+use openidconnect::{
+  AccessTokenHash, AuthorizationCode, ClientId, ClientSecret, CsrfToken, Nonce, OAuth2TokenResponse, PkceCodeChallenge,
+  PkceCodeVerifier, RedirectUrl, Scope, TokenResponse,
+};
+
+use crate::util::oidc::http_client::OidcHttpClient;
+
+/// The OIDC relying party configuration used by the authorization code flow
+pub struct OidcFlowConfig {
+  /// The OAuth2 client ID
+  pub client_id: String,
+  /// The OAuth2 client secret
+  pub client_secret: Option<String>,
+  /// The requested scopes
+  pub scopes: Vec<String>,
+  /// The redirect URL (constructed from the request and the configured redirect path)
+  pub redirect_url: String,
+  /// Additional accepted ID token audiences (besides the client ID)
+  pub audiences: Vec<String>,
+}
+
+/// The parameters of a started OIDC login
+pub struct BeginLogin {
+  /// The OIDC provider authorization URL to redirect the user to
+  pub authorization_url: String,
+  /// The OAuth2 state parameter
+  pub state: String,
+  /// The OpenID Connect nonce
+  pub nonce: String,
+  /// The PKCE code verifier
+  pub pkce_verifier: String,
+}
+
+/// The identity claims extracted from a verified ID token
+pub struct SessionClaims {
+  /// The OIDC subject identifier
+  pub sub: String,
+  /// The preferred username
+  pub username: Option<String>,
+  /// The email address
+  pub email: Option<String>,
+  /// The display name
+  pub name: Option<String>,
+  /// The groups the user belongs to
+  pub groups: Vec<String>,
+}
+
+/// The OIDC client type constructed from the provider metadata
+type ProviderCoreClient = CoreClient<
+  openidconnect::EndpointSet,
+  openidconnect::EndpointNotSet,
+  openidconnect::EndpointNotSet,
+  openidconnect::EndpointNotSet,
+  openidconnect::EndpointMaybeSet,
+  openidconnect::EndpointMaybeSet,
+>;
+
+/// Constructs an OIDC client from the provider metadata and the relying party configuration
+fn build_client(
+  metadata: CoreProviderMetadata,
+  config: &OidcFlowConfig,
+) -> Result<ProviderCoreClient, Box<dyn Error + Send + Sync>> {
+  Ok(
+    CoreClient::from_provider_metadata(
+      metadata,
+      ClientId::new(config.client_id.clone()),
+      config.client_secret.clone().map(ClientSecret::new),
+    )
+    .set_redirect_uri(
+      RedirectUrl::new(config.redirect_url.clone()).map_err(|e| anyhow::anyhow!("Invalid OIDC redirect URL: {e}"))?,
+    ),
+  )
+}
+
+/// Begins an OIDC login by generating the authorization URL with PKCE, state, and nonce
+pub fn begin_login(
+  metadata: CoreProviderMetadata,
+  config: &OidcFlowConfig,
+) -> Result<BeginLogin, Box<dyn Error + Send + Sync>> {
+  let client = build_client(metadata, config)?;
+  let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+  let mut authorization_request = client
+    .authorize_url(
+      CoreAuthenticationFlow::AuthorizationCode,
+      CsrfToken::new_random,
+      Nonce::new_random,
+    )
+    .set_pkce_challenge(pkce_challenge);
+  for scope in &config.scopes {
+    // The "openid" scope is always added by the OIDC library
+    if scope != "openid" {
+      authorization_request = authorization_request.add_scope(Scope::new(scope.clone()));
+    }
+  }
+  let (authorization_url, state, nonce) = authorization_request.url();
+  Ok(BeginLogin {
+    authorization_url: authorization_url.to_string(),
+    state: state.secret().clone(),
+    nonce: nonce.secret().clone(),
+    pkce_verifier: pkce_verifier.secret().clone(),
+  })
+}
+
+/// Exchanges an authorization code for tokens and verifies the ID token, extracting the
+/// identity claims
+pub async fn exchange_code(
+  metadata: CoreProviderMetadata,
+  config: &OidcFlowConfig,
+  http_client: &reqwest::Client,
+  code: String,
+  pkce_verifier: String,
+  nonce: String,
+) -> Result<SessionClaims, Box<dyn Error + Send + Sync>> {
+  let client = build_client(metadata, config)?;
+  let oidc_http_client = OidcHttpClient::new(http_client.clone());
+  let token_response = client
+    .exchange_code(AuthorizationCode::new(code))
+    .map_err(|e| anyhow::anyhow!("The OIDC provider doesn't support the token endpoint: {e}"))?
+    .set_pkce_verifier(PkceCodeVerifier::new(pkce_verifier))
+    .request_async(&oidc_http_client)
+    .await
+    .map_err(|e| anyhow::anyhow!("The OIDC authorization code exchange failed: {e}"))?;
+
+  let id_token = token_response
+    .id_token()
+    .ok_or_else(|| anyhow::anyhow!("The OIDC provider didn't return an ID token"))?;
+  let mut id_token_verifier = client.id_token_verifier();
+  if !config.audiences.is_empty() {
+    id_token_verifier =
+      id_token_verifier.set_other_audience_verifier_fn(|audience| config.audiences.iter().any(|a| a == &**audience));
+  }
+  let nonce = Nonce::new(nonce);
+  let claims = id_token
+    .claims(&id_token_verifier, &nonce)
+    .map_err(|e| anyhow::anyhow!("The OIDC ID token verification failed: {e}"))?;
+
+  // Verify the access token hash (if present) to ensure that the access token
+  // hasn't been substituted for another user's
+  if let Some(expected_access_token_hash) = claims.access_token_hash() {
+    let actual_access_token_hash = AccessTokenHash::from_token(
+      token_response.access_token(),
+      id_token
+        .signing_alg()
+        .map_err(|e| anyhow::anyhow!("Cannot determine the OIDC ID token signing algorithm: {e}"))?,
+      id_token
+        .signing_key(&id_token_verifier)
+        .map_err(|e| anyhow::anyhow!("Cannot determine the OIDC ID token signing key: {e}"))?,
+    )
+    .map_err(|e| anyhow::anyhow!("Cannot compute the OIDC access token hash: {e}"))?;
+    if actual_access_token_hash != *expected_access_token_hash {
+      Err(anyhow::anyhow!("Invalid OIDC access token hash"))?;
+    }
+  }
+
+  Ok(SessionClaims {
+    sub: claims.subject().to_string(),
+    username: claims.preferred_username().map(|v| v.to_string()),
+    email: claims.email().map(|v| v.to_string()),
+    name: claims.name().and_then(|name| name.get(None)).map(|v| v.to_string()),
+    groups: extract_groups(id_token),
+  })
+}
+
+/// Extracts the non-standard "groups" claim from a verified ID token by decoding its payload.
+/// This is safe, because the ID token signature has already been verified over this payload.
+fn extract_groups<T: serde::Serialize>(id_token: &T) -> Vec<String> {
+  let extract = || -> Option<Vec<String>> {
+    let jwt = match serde_json::to_value(id_token).ok()? {
+      serde_json::Value::String(jwt) => jwt,
+      _ => return None,
+    };
+    let payload = jwt.split('.').nth(1)?;
+    let decoded = BASE64_URL_SAFE_NO_PAD.decode(payload).ok()?;
+    let payload_json: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
+    Some(
+      payload_json
+        .get("groups")?
+        .as_array()?
+        .iter()
+        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+        .collect(),
+    )
+  };
+  extract().unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_extract_groups() {
+    let payload = serde_json::json!({"sub": "user", "groups": ["admins", "developers"]});
+    let jwt = format!(
+      "e30.{}.c2ln",
+      BASE64_URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap())
+    );
+    assert_eq!(
+      extract_groups(&jwt),
+      vec!["admins".to_string(), "developers".to_string()]
+    );
+  }
+
+  #[test]
+  fn test_extract_groups_missing() {
+    let payload = serde_json::json!({"sub": "user"});
+    let jwt = format!(
+      "e30.{}.c2ln",
+      BASE64_URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap())
+    );
+    assert!(extract_groups(&jwt).is_empty());
+  }
+}

--- a/ferron-modules-builtin/src/util/oidc/http_client.rs
+++ b/ferron-modules-builtin/src/util/oidc/http_client.rs
@@ -1,0 +1,81 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+use openidconnect::{AsyncHttpClient, HttpRequest, HttpResponse};
+
+/// The maximum accepted size of an OIDC provider response body
+const MAXIMUM_RESPONSE_BODY_SIZE: u64 = 1024 * 1024;
+
+/// The timeout for requests to the OIDC provider
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// An error occurring while sending a request to the OIDC provider
+#[derive(Debug)]
+pub struct OidcHttpClientError(String);
+
+impl std::fmt::Display for OidcHttpClientError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.write_str(&self.0)
+  }
+}
+
+impl std::error::Error for OidcHttpClientError {}
+
+/// Builds an HTTP client for communication with the OIDC provider
+pub fn build_http_client(no_verification: bool) -> Result<reqwest::Client, Box<dyn std::error::Error + Send + Sync>> {
+  let mut builder = reqwest::Client::builder()
+    .timeout(REQUEST_TIMEOUT)
+    // Following redirects opens the client up to SSRF vulnerabilities
+    .redirect(reqwest::redirect::Policy::none());
+  if no_verification {
+    builder = builder.danger_accept_invalid_certs(true);
+  }
+  Ok(
+    builder
+      .build()
+      .map_err(|e| anyhow::anyhow!("Failed to build the OIDC HTTP client: {e}"))?,
+  )
+}
+
+/// An `openidconnect` asynchronous HTTP client backed by a `reqwest` client
+pub struct OidcHttpClient(reqwest::Client);
+
+impl OidcHttpClient {
+  /// Wraps a `reqwest` client for use with the `openidconnect` crate
+  pub fn new(client: reqwest::Client) -> Self {
+    Self(client)
+  }
+}
+
+impl<'c> AsyncHttpClient<'c> for OidcHttpClient {
+  type Error = OidcHttpClientError;
+  type Future = Pin<Box<dyn Future<Output = Result<HttpResponse, OidcHttpClientError>> + Send + 'c>>;
+
+  fn call(&'c self, request: HttpRequest) -> Self::Future {
+    Box::pin(execute(&self.0, request))
+  }
+}
+
+/// Executes an OIDC provider request
+async fn execute(client: &reqwest::Client, request: HttpRequest) -> Result<HttpResponse, OidcHttpClientError> {
+  let request = reqwest::Request::try_from(request).map_err(|e| OidcHttpClientError(e.to_string()))?;
+  let response = client
+    .execute(request)
+    .await
+    .map_err(|e| OidcHttpClientError(e.to_string()))?;
+  if response.content_length().unwrap_or(0) > MAXIMUM_RESPONSE_BODY_SIZE {
+    return Err(OidcHttpClientError("OIDC provider response body too large".to_string()));
+  }
+  let mut builder = openidconnect::http::Response::builder().status(response.status());
+  if let Some(headers) = builder.headers_mut() {
+    *headers = response.headers().clone();
+  }
+  let body = response.bytes().await.map_err(|e| OidcHttpClientError(e.to_string()))?;
+  if body.len() as u64 > MAXIMUM_RESPONSE_BODY_SIZE {
+    return Err(OidcHttpClientError("OIDC provider response body too large".to_string()));
+  }
+  builder
+    .body(body.to_vec())
+    .map_err(|e| OidcHttpClientError(e.to_string()))
+}

--- a/ferron-modules-builtin/src/util/oidc/mod.rs
+++ b/ferron-modules-builtin/src/util/oidc/mod.rs
@@ -1,0 +1,4 @@
+pub mod cookie;
+pub mod flow;
+pub mod http_client;
+pub mod provider;

--- a/ferron-modules-builtin/src/util/oidc/provider.rs
+++ b/ferron-modules-builtin/src/util/oidc/provider.rs
@@ -1,0 +1,97 @@
+use std::error::Error;
+use std::time::{Duration, Instant};
+
+use openidconnect::core::CoreProviderMetadata;
+use openidconnect::IssuerUrl;
+use tokio::sync::RwLock;
+
+use crate::util::oidc::http_client::OidcHttpClient;
+
+/// The time after which the cached OIDC provider metadata is refreshed
+const METADATA_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// The time during which OIDC provider metadata fetches aren't retried after a failure
+const FAILURE_BACKOFF: Duration = Duration::from_secs(10);
+
+/// A cache for OIDC provider metadata obtained through OpenID Connect Discovery
+pub struct ProviderCache {
+  state: RwLock<ProviderCacheState>,
+}
+
+#[derive(Default)]
+struct ProviderCacheState {
+  metadata: Option<(CoreProviderMetadata, Instant)>,
+  last_failure: Option<Instant>,
+}
+
+impl Default for ProviderCache {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl ProviderCache {
+  /// Creates an empty OIDC provider metadata cache
+  pub fn new() -> Self {
+    Self {
+      state: RwLock::new(ProviderCacheState::default()),
+    }
+  }
+
+  /// Obtains the OIDC provider metadata, fetching it through OpenID Connect Discovery if
+  /// it's not cached or the cached metadata expired
+  pub async fn get_metadata(
+    &self,
+    http_client: &reqwest::Client,
+    issuer_url: &str,
+  ) -> Result<CoreProviderMetadata, Box<dyn Error + Send + Sync>> {
+    {
+      let state = self.state.read().await;
+      if let Some((metadata, fetched_at)) = &state.metadata {
+        if fetched_at.elapsed() < METADATA_TTL {
+          return Ok(metadata.clone());
+        }
+      }
+    }
+    self.refresh_metadata(http_client, issuer_url).await
+  }
+
+  /// Fetches the OIDC provider metadata through OpenID Connect Discovery, bypassing
+  /// the cached metadata (used for OIDC provider signing key rotation)
+  pub async fn refresh_metadata(
+    &self,
+    http_client: &reqwest::Client,
+    issuer_url: &str,
+  ) -> Result<CoreProviderMetadata, Box<dyn Error + Send + Sync>> {
+    let mut state = self.state.write().await;
+
+    if let Some(last_failure) = state.last_failure {
+      if last_failure.elapsed() < FAILURE_BACKOFF {
+        // Serve stale metadata if available instead of hammering a failing OIDC provider
+        if let Some((metadata, _)) = &state.metadata {
+          return Ok(metadata.clone());
+        }
+        Err(anyhow::anyhow!("The OIDC provider metadata cannot be fetched"))?;
+      }
+    }
+
+    let issuer_url_parsed =
+      IssuerUrl::new(issuer_url.to_string()).map_err(|e| anyhow::anyhow!("Invalid OIDC issuer URL: {e}"))?;
+    let oidc_http_client = OidcHttpClient::new(http_client.clone());
+    match CoreProviderMetadata::discover_async(issuer_url_parsed, &oidc_http_client).await {
+      Ok(metadata) => {
+        state.metadata = Some((metadata.clone(), Instant::now()));
+        state.last_failure = None;
+        Ok(metadata)
+      }
+      Err(e) => {
+        state.last_failure = Some(Instant::now());
+        // Serve stale metadata if available
+        if let Some((metadata, _)) = &state.metadata {
+          return Ok(metadata.clone());
+        }
+        Err(anyhow::anyhow!("Failed to fetch the OIDC provider metadata: {e}"))?
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the `oidc` module: an OpenID Connect relying party using the authorization code flow with PKCE, comparable to oauth2-proxy. It works with any spec-compliant OIDC provider (Authelia, Keycloak, ...). Independent of #888.

- **Flow**: unauthenticated navigation requests are redirected to the provider's authorization endpoint (state, nonce, and PKCE verifier kept in a short-lived encrypted state cookie); the callback exchanges the code, verifies the ID token, and redirects to the originally requested path (open-redirect safe). API-style requests (non-GET/HEAD, `Sec-Fetch-Mode: cors`, `X-Requested-With`) get 401 instead of a redirect.
- **Verification** via the `openidconnect` crate: issuer, signature through the discovered JWKS, audience (plus configurable extra audiences), nonce, and access token hash. Provider metadata is discovered lazily and cached (24 h TTL, 10 s failure backoff, refresh after verification failures to cope with signing key rotation).
- **Session**: XChaCha20-Poly1305-encrypted cookie with HKDF-derived keys (`HttpOnly; SameSite=Lax; Secure` on TLS). No tokens are stored client-side and no server-side session store is needed, so sessions work across worker threads and across instances when `auth_oidc_cookie_secret` is configured.
- **Identity headers**: `Remote-User`, `Remote-Groups`, `Remote-Email`, `Remote-Name` (Authelia's conventions) are provided to backends and always stripped from client requests; the username also feeds `REMOTE_USER` for CGI/SCGI/FastCGI and the `{auth_user}` log placeholder. Optional group-based authorization via `auth_oidc_allowed_groups`.
- **HTTP client**: `reqwest` 0.13 (already in the dependency tree) with redirects disabled, 10 s timeout, and a 1 MiB response cap; `openidconnect`'s own `reqwest` feature is not enabled to avoid pulling in a second `reqwest` 0.12 stack.
- **Runtimes**: all provider-facing I/O runs on the secondary Tokio runtime, so the module works on monoio, tokio, and vibeio.
- **3.x portability**: directive names (`auth_oidc`, `auth_oidc_client_id`, ...) map directly onto an `auth_oidc { client_id ... }` block directive in the 3.x module architecture (same pattern as `auth_to`), and the core (cookie sealing, flow, provider cache, HTTP client) lives in `util/oidc/` without Ferron-2.x-specific coupling.
- Docs: directive reference in `docs/configuration/security-tls.md`, module notes, and a new `docs/use-cases/oidc-authentication.md` with Authelia and Keycloak examples.

## Test plan

- Unit tests: cookie sealing/unsealing, tamper and wrong-key rejection, cookie parsing, redirect-target sanitizing, groups claim extraction (`cargo test -p ferron-modules-builtin`)
- New e2e tests (`e2e/tests/oidc.rs`) against `ghcr.io/navikt/mock-oauth2-server`: full login round-trip with `Remote-User` visible at the backend, logout, invalid session cookie, API request → 401, callback without state → 400. Note: these were type-checked but not executed locally (no Docker available); the `e2e` CI job exercises them.
- `cargo build` on all three runtime feature sets, `cargo clippy -- --deny warnings`, and `cargo fmt --check` pass

## Notes

- `rsa` (pulled in by `openidconnect` for RS256 verification) is affected by RUSTSEC-2023-0071 (Marvin attack); it only concerns private-key operations, and Ferron performs public-key verification only.
- Not in scope for this first version: refresh tokens and RP-initiated logout at the provider (`end_session_endpoint`); the logout path only clears the local session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)